### PR TITLE
fix(claude): remove redundant hooks reference

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -13,6 +13,5 @@
   "keywords": ["litestar", "skills", "agent", "ai", "sqlspec", "advanced-alchemy", "granian", "msgspec", "dishka", "mcp"],
   "skills": ["./skills/"],
   "commands": ["./commands/"],
-  "agents": ["./.claude-plugin/agents/litestar-reviewer.md"],
-  "hooks": "./hooks/hooks.json"
+  "agents": ["./.claude-plugin/agents/litestar-reviewer.md"]
 }


### PR DESCRIPTION
Claude Code automatically loads 'hooks/hooks.json', so explicitly referencing it in 'plugin.json' causes a 'Duplicate hooks file detected' error. This PR removes the redundant reference.