### PR TITLE
fix: self-locating SessionStart hook so it can't exit 127 across hosts

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -14,7 +14,7 @@
   "plugins": [
     {
       "name": "litestar",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "description": "Opinionated first-party agent skills, plugins, subagents, slash commands, and MCP servers for the Litestar framework ecosystem",
       "source": { "source": "local", "path": "./plugins/litestar" },
       "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "litestar",
       "source": "./",
       "description": "Opinionated first-party agent skills, plugins, subagents, slash commands, and MCP servers for the Litestar framework ecosystem",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "author": {
         "name": "Cody Fincher",
         "email": "cofin@litestar.dev"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "litestar",
   "description": "Opinionated first-party agent skills, plugins, subagents, slash commands, and MCP servers for the Litestar framework ecosystem",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {
     "name": "Cody Fincher",
     "email": "cofin@litestar.dev"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "litestar",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Opinionated first-party agent skills for the Litestar framework ecosystem",
   "author": {
     "name": "Cody Fincher",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "litestar",
   "displayName": "Litestar",
   "description": "Opinionated first-party agent skills, plugins, subagents, slash commands, and MCP servers for the Litestar framework ecosystem",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {
     "name": "Cody Fincher",
     "email": "cofin@litestar.dev"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Status
 
-**v0.2.0 — early access.** Multi-host plumbing, 28 skills, ~28,500 lines of canonical content. Full launch-skill catalog growing.
+**v0.2.1 — early access.** Multi-host plumbing, 28 skills, ~28,500 lines of canonical content. Full launch-skill catalog growing.
 
 **Breaking host identity note:** host-facing marketplace, plugin, extension, managed-config, and skill namespace IDs are `litestar`. Existing installs under `litestar-skills` should be removed and reinstalled; no alias is shipped. The Python package and repository remain `litestar-skills`.
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "litestar",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Opinionated first-party agent skills for the Litestar framework ecosystem",
   "contextFileName": "GEMINI.md",
   "excludeTools": [

--- a/hooks/hooks-claude.json
+++ b/hooks/hooks-claude.json
@@ -7,7 +7,7 @@
           {
             "name": "litestar-session-start",
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\"",
+            "command": "r=\"${CLAUDE_PLUGIN_ROOT:-}\"; [ -n \"$r\" ] || r=\"$(ls -d \"$HOME\"/.claude/plugins/marketplaces/litestar \"$HOME\"/.claude/plugins/marketplaces/*/plugins/litestar 2>/dev/null | head -n1)\"; r=\"${r:-.}\"; CLAUDE_PLUGIN_ROOT=\"${r%/}\" bash \"${r%/}/hooks/session-start.sh\"",
             "description": "Inject project-aware Litestar skill reminders into the session context.",
             "async": false
           }

--- a/hooks/hooks-codex.json
+++ b/hooks/hooks-codex.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CODEX_PLUGIN_ROOT}/hooks/session-start.sh",
+            "command": "r=\"${PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}}\"; [ -n \"$r\" ] || r=\"$(ls -d \"$HOME\"/.codex/plugins/cache/*/litestar/*/ 2>/dev/null | sort -V | tail -n1)\"; r=\"${r:-.}\"; CODEX_PLUGIN_ROOT=\"${r%/}\" bash \"${r%/}/hooks/session-start.sh\"",
             "timeout": 30,
             "description": "Inject project-aware Litestar skill reminders into the Codex CLI session context."
           }

--- a/hooks/hooks-cursor.json
+++ b/hooks/hooks-cursor.json
@@ -4,7 +4,7 @@
     "sessionStart": [
       {
         "name": "litestar-session-start",
-        "command": "bash ./hooks/session-start.sh",
+        "command": "r=\"${CURSOR_PLUGIN_ROOT:-.}\"; CURSOR_PLUGIN_ROOT=\"${r%/}\" bash \"${r%/}/hooks/session-start.sh\"",
         "description": "Inject project-aware Litestar skill reminders into the Cursor session context."
       }
     ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "litestar-skills",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Opinionated first-party agent skills, plugins, subagents, slash commands, and MCP servers for the Litestar framework ecosystem",
   "main": ".opencode/plugins/litestar.js",
   "type": "module",

--- a/plugins/litestar/.codex-plugin/plugin.json
+++ b/plugins/litestar/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "litestar",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Opinionated first-party agent skills for the Litestar framework ecosystem",
   "author": {
     "name": "Cody Fincher",

--- a/plugins/litestar/hooks/hooks-claude.json
+++ b/plugins/litestar/hooks/hooks-claude.json
@@ -7,7 +7,7 @@
           {
             "name": "litestar-session-start",
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\"",
+            "command": "r=\"${CLAUDE_PLUGIN_ROOT:-}\"; [ -n \"$r\" ] || r=\"$(ls -d \"$HOME\"/.claude/plugins/marketplaces/litestar \"$HOME\"/.claude/plugins/marketplaces/*/plugins/litestar 2>/dev/null | head -n1)\"; r=\"${r:-.}\"; CLAUDE_PLUGIN_ROOT=\"${r%/}\" bash \"${r%/}/hooks/session-start.sh\"",
             "description": "Inject project-aware Litestar skill reminders into the session context.",
             "async": false
           }

--- a/plugins/litestar/hooks/hooks-codex.json
+++ b/plugins/litestar/hooks/hooks-codex.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CODEX_PLUGIN_ROOT}/hooks/session-start.sh",
+            "command": "r=\"${PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}}\"; [ -n \"$r\" ] || r=\"$(ls -d \"$HOME\"/.codex/plugins/cache/*/litestar/*/ 2>/dev/null | sort -V | tail -n1)\"; r=\"${r:-.}\"; CODEX_PLUGIN_ROOT=\"${r%/}\" bash \"${r%/}/hooks/session-start.sh\"",
             "timeout": 30,
             "description": "Inject project-aware Litestar skill reminders into the Codex CLI session context."
           }

--- a/plugins/litestar/hooks/hooks-cursor.json
+++ b/plugins/litestar/hooks/hooks-cursor.json
@@ -4,7 +4,7 @@
     "sessionStart": [
       {
         "name": "litestar-session-start",
-        "command": "bash ./hooks/session-start.sh",
+        "command": "r=\"${CURSOR_PLUGIN_ROOT:-.}\"; CURSOR_PLUGIN_ROOT=\"${r%/}\" bash \"${r%/}/hooks/session-start.sh\"",
         "description": "Inject project-aware Litestar skill reminders into the Cursor session context."
       }
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "litestar-skills"
-version = "0.2.0"
+version = "0.2.1"
 description = "Opinionated first-party agent skills, plugins, subagents, slash commands, and MCP servers for the Litestar framework ecosystem"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -154,7 +154,7 @@ exclude_lines = [
 # bump-my-version — atomic multi-manifest version sync
 # ============================================================
 [tool.bumpversion]
-current_version = "0.2.0"
+current_version = "0.2.1"
 commit = false
 tag = false
 tag_name = "v{new_version}"

--- a/tests/hooks/test_session_start_invocation.py
+++ b/tests/hooks/test_session_start_invocation.py
@@ -74,6 +74,16 @@ def fake_codex_home(tmp_path: Path) -> Path:
     return home
 
 
+@pytest.fixture
+def fake_claude_home(tmp_path: Path) -> Path:
+    """A HOME whose Claude marketplace install mirrors the real hooks payload."""
+    home = tmp_path / "home"
+    install = home / ".claude" / "plugins" / "marketplaces" / "litestar"
+    install.mkdir(parents=True)
+    (install / "hooks").symlink_to(HOOKS_DIR)
+    return home
+
+
 def test_codex_command_resolves_without_plugin_root(litestar_project: Path, fake_codex_home: Path) -> None:
     """Codex injects no plugin-root var: the command must locate the installed script and exit 0."""
     result = _run_command(
@@ -96,6 +106,31 @@ def test_codex_command_prefers_plugin_root_when_set(litestar_project: Path) -> N
         overrides={"PLUGIN_ROOT": str(REPO_ROOT)},
     )
     assert result.returncode == 0, f"codex command exited {result.returncode}: {result.stderr!r}"
+    out = cast("dict[str, Any]", json.loads(result.stdout))
+    assert out["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+
+
+def test_claude_command_uses_plugin_root_when_set(litestar_project: Path) -> None:
+    """Non-regression: the guaranteed CLAUDE_PLUGIN_ROOT path must keep working verbatim."""
+    result = _run_command(
+        _command_for("claude"),
+        cwd=litestar_project,
+        overrides={"CLAUDE_PLUGIN_ROOT": str(REPO_ROOT)},
+    )
+    assert result.returncode == 0, f"claude command exited {result.returncode}: {result.stderr!r}"
+    out = cast("dict[str, Any]", json.loads(result.stdout))
+    assert out["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+    assert "litestar:litestar" in out["hookSpecificOutput"]["additionalContext"]
+
+
+def test_claude_command_resolves_with_empty_plugin_root(litestar_project: Path, fake_claude_home: Path) -> None:
+    """claude-code#27145: CLAUDE_PLUGIN_ROOT can be empty at SessionStart — must not exit 127."""
+    result = _run_command(
+        _command_for("claude"),
+        cwd=litestar_project,
+        overrides={"CLAUDE_PLUGIN_ROOT": "", "HOME": str(fake_claude_home)},
+    )
+    assert result.returncode == 0, f"claude command exited {result.returncode}: {result.stderr!r}"
     out = cast("dict[str, Any]", json.loads(result.stdout))
     assert out["hookSpecificOutput"]["hookEventName"] == "SessionStart"
 

--- a/tests/hooks/test_session_start_invocation.py
+++ b/tests/hooks/test_session_start_invocation.py
@@ -1,0 +1,113 @@
+"""Tests for the per-host hook *manifest command strings* — not the script.
+
+`hooks/session-start.sh` is already self-locating (covered by
+``test_session_start_emission.py``). The defect class these tests guard against
+lives in the manifest ``command`` strings: a host that does not inject its
+``*_PLUGIN_ROOT`` variable (Codex) or runs the hook from a foreign CWD (Cursor)
+must still resolve the script and exit 0 — never ``bash /hooks/session-start.sh``
+(exit 127, GitHub #23).
+
+Each test executes the manifest's real command via ``bash -c`` so a regression in
+the command bytes is caught here before it ships.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from tests.hooks._subproc import bash_executable, subprocess_env
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOKS_DIR = REPO_ROOT / "hooks"
+
+# Manifest filename + the JSON event key per host.
+MANIFESTS = {
+    "claude": ("hooks-claude.json", "SessionStart"),
+    "codex": ("hooks-codex.json", "SessionStart"),
+    "cursor": ("hooks-cursor.json", "sessionStart"),
+}
+
+
+def _command_for(host: str) -> str:
+    filename, event = MANIFESTS[host]
+    data = cast("dict[str, Any]", json.loads((HOOKS_DIR / filename).read_text(encoding="utf-8")))
+    matcher = data["hooks"][event][0]
+    # Claude/Codex nest a "hooks" array under the matcher; Cursor puts "command" on the matcher directly.
+    entry = matcher["hooks"][0] if "hooks" in matcher else matcher
+    return cast("str", entry["command"])
+
+
+def _run_command(command: str, *, cwd: Path, overrides: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    env = subprocess_env(overrides={"PWD": str(cwd), **overrides})
+    return subprocess.run(
+        [bash_executable(), "-c", command],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(cwd),
+        check=False,
+        timeout=10,
+    )
+
+
+@pytest.fixture
+def litestar_project(tmp_path: Path) -> Path:
+    """A foreign working directory that the detector recognizes as a Litestar app."""
+    project = tmp_path / "userproject"
+    project.mkdir()
+    (project / "pyproject.toml").write_text('[project]\nname = "myapp"\ndependencies = ["litestar"]\n')
+    return project
+
+
+@pytest.fixture
+def fake_codex_home(tmp_path: Path) -> Path:
+    """A HOME whose Codex install cache mirrors the real hooks payload (newest version)."""
+    home = tmp_path / "home"
+    cache = home / ".codex" / "plugins" / "cache" / "litestar" / "litestar" / "0.2.1"
+    cache.mkdir(parents=True)
+    (cache / "hooks").symlink_to(HOOKS_DIR)
+    return home
+
+
+def test_codex_command_resolves_without_plugin_root(litestar_project: Path, fake_codex_home: Path) -> None:
+    """Codex injects no plugin-root var: the command must locate the installed script and exit 0."""
+    result = _run_command(
+        _command_for("codex"),
+        cwd=litestar_project,
+        overrides={"HOME": str(fake_codex_home)},
+    )
+    assert result.returncode == 0, f"codex command exited {result.returncode}: {result.stderr!r}"
+    out = cast("dict[str, Any]", json.loads(result.stdout))
+    assert "hookSpecificOutput" in out, out
+    assert out["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+    assert "litestar:litestar" in out["hookSpecificOutput"]["additionalContext"]
+
+
+def test_codex_command_prefers_plugin_root_when_set(litestar_project: Path) -> None:
+    """When Codex (or its alias) does inject the root, the command uses it verbatim."""
+    result = _run_command(
+        _command_for("codex"),
+        cwd=litestar_project,
+        overrides={"PLUGIN_ROOT": str(REPO_ROOT)},
+    )
+    assert result.returncode == 0, f"codex command exited {result.returncode}: {result.stderr!r}"
+    out = cast("dict[str, Any]", json.loads(result.stdout))
+    assert out["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+
+
+def test_cursor_command_uses_plugin_root_not_cwd(litestar_project: Path) -> None:
+    """Cursor sets CURSOR_PLUGIN_ROOT but runs from a foreign CWD: the command must honor the var."""
+    result = _run_command(
+        _command_for("cursor"),
+        cwd=litestar_project,
+        overrides={"CURSOR_PLUGIN_ROOT": str(REPO_ROOT)},
+    )
+    assert result.returncode == 0, f"cursor command exited {result.returncode}: {result.stderr!r}"
+    out = cast("dict[str, Any]", json.loads(result.stdout))
+    assert "additional_context" in out, out
+    assert "litestar:litestar" in str(out["additional_context"])

--- a/tools/install.ps1
+++ b/tools/install.ps1
@@ -75,7 +75,7 @@ Set-StrictMode -Version Latest
 # =============================================================================
 # Constants
 # =============================================================================
-$script:Version = '0.2.0'
+$script:Version = '0.2.1'
 $script:RepoUrl = 'https://github.com/litestar-org/litestar-skills'
 $script:RepoSlug = 'litestar-org/litestar-skills'
 $script:MarketplaceName = 'litestar'

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -8,7 +8,7 @@
 #
 # Usage:
 #   tools/install.sh [--dry-run] [--force] [--only <host>] [--skip <host>]
-#   curl -fsSL https://raw.githubusercontent.com/litestar-org/litestar-skills/v0.2.0/tools/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/litestar-org/litestar-skills/v0.2.1/tools/install.sh | bash
 #
 # Hosts:
 #   claude     Claude Code        (prints instructions + optional settings edit)
@@ -20,7 +20,7 @@
 
 set -euo pipefail
 
-VERSION="0.2.0"
+VERSION="0.2.1"
 REPO_URL="https://github.com/litestar-org/litestar-skills"
 REPO_SLUG="litestar-org/litestar-skills"
 MARKETPLACE_NAME="litestar"

--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-VERSION="0.2.0"
+VERSION="0.2.1"
 PLUGIN_NAME="litestar"
 REPO_SLUG="litestar-org/litestar-skills"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1427,7 +1427,7 @@ wheels = [
 
 [[package]]
 name = "litestar-skills"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Problem

On Codex CLI, the plugin's SessionStart hook failed on every session start:

```
• SessionStart hook (failed)
  error: hook exited with code 127
```

The Codex manifest ran `bash ${CODEX_PLUGIN_ROOT}/hooks/session-start.sh`, but Codex never sets `CODEX_PLUGIN_ROOT` (it injects `PLUGIN_ROOT`). The variable expanded to empty, so the command collapsed to `bash /hooks/session-start.sh` → "No such file or directory" → exit 127. Fixes #23.

The bug was isolated to the manifest **command strings** — `hooks/session-start.sh` was already self-locating. The same class of fragility existed in the other host manifests.

## Fix

Make the per-host hook commands self-locating, always resolving a non-empty script path:

- **Codex** — resolve the plugin root from `PLUGIN_ROOT` (canonical), then `CODEX_PLUGIN_ROOT`/`CLAUDE_PLUGIN_ROOT`, then the install cache (newest version), then cwd. Re-export `CODEX_PLUGIN_ROOT` so the script still emits the correct host JSON shape.
- **Cursor** — resolve from `CURSOR_PLUGIN_ROOT` instead of a cwd-relative `./hooks/...`, so the hook survives being run from a foreign working directory.
- **Claude** — keep `CLAUDE_PLUGIN_ROOT` as the first-choice branch (behavior is unchanged when it is set) and only add a fallback when it is empty, closing the documented edge where `CLAUDE_PLUGIN_ROOT` is empty at SessionStart (claude-code#27145).
- **Gemini** — intentionally left as-is: it relies on host-expanded `${extensionPath}` tokens (a different mechanism) and has no reported failure.

## Tests

New smoke tests execute each manifest's **real command string** with the plugin-root variable unset / empty / from a foreign cwd and assert exit 0 plus valid host JSON — the regression that previously shipped. Includes a Claude non-regression guard proving the variable-set path is unchanged.

## Verification

- `make check` green (lint, type-check, 37 hook tests, all validators).
- Codex package mirror regenerated (`make sync-codex-package`); `make codex-package-check` passes.
- Version bumped `0.2.0 → 0.2.1` across all manifests.