### PR TITLE
fix(litestar-mcp): align skill with litestar-mcp 0.7.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -14,7 +14,7 @@
   "plugins": [
     {
       "name": "litestar",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "description": "Opinionated first-party agent skills, plugins, subagents, slash commands, and MCP servers for the Litestar framework ecosystem",
       "source": { "source": "local", "path": "./plugins/litestar" },
       "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "litestar",
       "source": "./",
       "description": "Opinionated first-party agent skills, plugins, subagents, slash commands, and MCP servers for the Litestar framework ecosystem",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "author": {
         "name": "Cody Fincher",
         "email": "cofin@litestar.dev"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "litestar",
   "description": "Opinionated first-party agent skills, plugins, subagents, slash commands, and MCP servers for the Litestar framework ecosystem",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "author": {
     "name": "Cody Fincher",
     "email": "cofin@litestar.dev"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "litestar",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Opinionated first-party agent skills for the Litestar framework ecosystem",
   "author": {
     "name": "Cody Fincher",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "litestar",
   "displayName": "Litestar",
   "description": "Opinionated first-party agent skills, plugins, subagents, slash commands, and MCP servers for the Litestar framework ecosystem",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "author": {
     "name": "Cody Fincher",
     "email": "cofin@litestar.dev"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Status
 
-**v0.2.1 — early access.** Multi-host plumbing, 28 skills, ~28,500 lines of canonical content. Full launch-skill catalog growing.
+**v0.3.0 — early access.** Multi-host plumbing, 28 skills, ~28,500 lines of canonical content. Full launch-skill catalog growing.
 
 **Breaking host identity note:** host-facing marketplace, plugin, extension, managed-config, and skill namespace IDs are `litestar`. Existing installs under `litestar-skills` should be removed and reinstalled; no alias is shipped. The Python package and repository remain `litestar-skills`.
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "litestar",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Opinionated first-party agent skills for the Litestar framework ecosystem",
   "contextFileName": "GEMINI.md",
   "excludeTools": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "litestar-skills",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Opinionated first-party agent skills, plugins, subagents, slash commands, and MCP servers for the Litestar framework ecosystem",
   "main": ".opencode/plugins/litestar.js",
   "type": "module",

--- a/plugins/litestar/.codex-plugin/plugin.json
+++ b/plugins/litestar/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "litestar",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Opinionated first-party agent skills for the Litestar framework ecosystem",
   "author": {
     "name": "Cody Fincher",

--- a/plugins/litestar/skills/litestar-mcp/SKILL.md
+++ b/plugins/litestar/skills/litestar-mcp/SKILL.md
@@ -5,9 +5,9 @@ description: "Auto-activate for litestar_mcp, LitestarMCP, MCPConfig, MCPAuthCon
 
 # litestar-mcp
 
-`litestar-mcp` exposes explicitly marked Litestar route handlers as [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) tools and resources over MCP Streamable HTTP and JSON-RPC 2.0.
+`litestar-mcp` exposes explicitly marked Litestar route handlers as [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) tools, resources, and prompts over MCP Streamable HTTP and JSON-RPC 2.0.
 
-Mark routes with `mcp_tool="name"` or `mcp_resource="name"` directly on Litestar route decorators. Do not use the removed `@mcp_tool` / `@mcp_resource` decorator API or `opt={"mcp_tool_name": ...}` wrappers.
+Mark routes by passing `mcp_tool="name"`, `mcp_resource="name"`, or `mcp_prompt="name"` directly to the Litestar route decorator — Litestar funnels unknown kwargs into `handler.opt`, so no `opt={...}` wrapper is needed. The `@mcp_tool` / `@mcp_resource` / `@mcp_prompt` decorators (importable from `litestar_mcp`) still exist and are worth reaching for when you need the extra fields they expose — `output_schema`, `annotations`, `scopes`, `task_support`, prompt `arguments`. There is no `opt={"mcp_tool_name": ...}` form and no `mcp_exclude` key; neither is read. To hide a route, simply leave it unmarked (discovery is opt-in).
 
 ## Code Style Rules
 
@@ -58,10 +58,11 @@ The default MCP surface is:
 | Endpoint | Purpose |
 | --- | --- |
 | `GET /mcp` | Server-Sent Events stream when requested by the client |
-| `POST /mcp` | JSON-RPC endpoint for `initialize`, `ping`, `tools/*`, `resources/*`, and optional task methods |
+| `POST /mcp` | JSON-RPC endpoint for `initialize`, `ping`, `tools/*`, `resources/*`, `prompts/*`, `completion/complete`, and optional task methods |
+| `DELETE /mcp` | Terminate the current MCP session |
 | `GET /.well-known/mcp-server.json` | MCP server manifest |
 | `GET /.well-known/agent-card.json` | Agent card metadata |
-| `GET /.well-known/oauth-protected-resource` | OAuth protected-resource metadata when auth is configured |
+| `GET /.well-known/oauth-protected-resource` | OAuth protected-resource metadata (always registered; populated from `auth`) |
 
 ### MCPConfig
 
@@ -78,6 +79,14 @@ The default MCP surface is:
 | `exclude_tags` | `list[str] \| None` | `None` | Exclude routes with matching OpenAPI tags |
 | `auth` | `MCPAuthConfig \| None` | `None` | OAuth protected-resource metadata |
 | `tasks` | `bool \| MCPTaskConfig` | `False` | Enable experimental in-memory MCP task support |
+| `list_page_size` | `int` | `100` | Page size for `tools/list`, `resources/list`, `resources/templates/list`, `prompts/list` (clients page via opaque cursors) |
+| `opt_keys` | `MCPOptKeys` | `MCPOptKeys()` | Rename the `handler.opt` keys the plugin reads (e.g. to avoid collisions) |
+| `session_store` | `Store \| None` | `None` | Litestar `Store` backing MCP sessions; defaults to an in-memory store |
+| `session_max_idle_seconds` | `float` | `3600.0` | Idle timeout before an MCP session is evicted |
+| `sse_max_streams` | `int` | `10000` | Max concurrent SSE streams |
+| `sse_max_idle_seconds` | `float` | `3600.0` | Idle timeout for an SSE stream |
+
+> Filters (`include_tags` / `exclude_tags` / `include_operations` / `exclude_operations`) gate what is **advertised** in `tools/list` / `resources/list` / `prompts/list`. As of `litestar-mcp` 0.7.0 they do **not** gate `tools/call` / `resources/read` ([cofin/litestar-mcp#62](https://github.com/cofin/litestar-mcp/issues/62)), so they are an advertisement filter, not an access boundary — use `guards` / auth to actually restrict invocation.
 
 ### Route Marking
 
@@ -93,8 +102,34 @@ async def list_products() -> list[dict]: ...
 async def add_to_cart(data: CartItem) -> Cart: ...
 
 
-@get("/products/{product_id:int}", mcp_resource_template="shop://products/{product_id}")
+@get(
+    "/products/{product_id:int}",
+    mcp_resource="product",
+    mcp_resource_template="shop://products/{product_id}",
+)
 async def get_product(product_id: int) -> dict: ...
+
+
+@get("/products/{product_id:int}/blurb", mcp_prompt="product_blurb")
+async def product_blurb(product_id: int) -> str:
+    """Write a short marketing blurb for a product."""
+    ...
+```
+
+`mcp_resource_template` only takes effect alongside `mcp_resource` — the resource supplies the name the template binds to. A handler can expose more than one MCP role (a tool and a resource) at once; the description-override keys (`mcp_description` vs `mcp_resource_description`) are kind-specific so each surface can carry its own prose.
+
+Register prompts not bound to a route with the `@mcp_prompt` decorator plus `LitestarMCP(prompts=[...])`:
+
+```python
+from litestar_mcp import LitestarMCP, mcp_prompt
+
+
+@mcp_prompt("summarize", description="Summarize a document for the user.")
+def summarize(text: str) -> str:
+    return f"Summarize the following:\n\n{text}"
+
+
+app = Litestar(plugins=[LitestarMCP(prompts=[summarize])])
 ```
 
 Use structured metadata when the agent needs sharper tool selection:
@@ -110,12 +145,16 @@ Use structured metadata when the agent needs sharper tool selection:
 async def generate_report(data: ReportRequest) -> ReportQueued: ...
 ```
 
-### Excluding Routes
+### Hiding Routes
+
+Discovery is opt-in: a handler that carries no `mcp_*` marker never appears in MCP. There is no per-route exclude flag — `opt={"mcp_exclude": True}` is ignored.
 
 ```python
-@get("/internal/metrics", opt={"mcp_exclude": True})
+@get("/internal/metrics")  # unmarked — never exposed to MCP clients
 async def metrics() -> dict: ...
 ```
+
+To drop *marked* routes from discovery in bulk, use the `MCPConfig` filters (`exclude_tags` / `exclude_operations`, or an `include_tags` / `include_operations` allowlist). Remember these gate advertisement only ([cofin/litestar-mcp#62](https://github.com/cofin/litestar-mcp/issues/62)) — enforce real access control with `guards` or auth.
 
 ### JSON-RPC Call
 
@@ -191,7 +230,7 @@ pip install litestar-mcp
 
 ### Step 2: Decide What to Expose
 
-List only the routes that should be callable by AI clients. Mark those routes with `mcp_tool=`, `mcp_resource=`, or `mcp_resource_template=`. Do not rely on route method defaults.
+List only the routes that should be callable by AI clients. Mark those routes with `mcp_tool=`, `mcp_resource=`, or `mcp_prompt=` (add `mcp_resource_template=` next to `mcp_resource=` for templated resources). There are no method-based defaults — unmarked routes are never exposed.
 
 ### Step 3: Add the Plugin
 
@@ -212,7 +251,7 @@ Hit `POST /mcp` with `tools/list` and `resources/list`. Confirm only marked rout
 ## Guardrails
 
 - **Mark routes explicitly** - unmarked routes should not appear in MCP clients.
-- **Default to allowlists** - `include_tags` / `include_operations` prevent accidental exposure when route sets grow.
+- **Default to allowlists for discovery** - `include_tags` / `include_operations` keep the advertised tool set small as route counts grow, but they only filter discovery — pair them with `guards` / auth, which actually gate invocation.
 - **Never expose admin or destructive routes by default** - require a human-confirmation workflow before any irreversible operation.
 - **Prefer resources for read-only reference data** - agents may read resources speculatively.
 - **Keep DTOs precise** - loose `dict[str, Any]` request schemas produce weak tool contracts.
@@ -229,7 +268,7 @@ Before delivering an MCP integration, verify:
 
 - [ ] `LitestarMCP` is in `app.plugins`
 - [ ] Exposed routes use `mcp_tool=`, `mcp_resource=`, or `mcp_resource_template=`
-- [ ] Admin / internal routes use `opt={"mcp_exclude": True}` or are outside the allowlist
+- [ ] Admin / internal routes are left unmarked, or kept outside `include_*` / inside `exclude_*` — with `guards` or auth enforcing access
 - [ ] Auth is configured for the deployment boundary
 - [ ] `POST /mcp` `tools/list` returns only intended tools
 - [ ] `POST /mcp` `resources/list` includes only intended resources plus `litestar://openapi`
@@ -258,7 +297,7 @@ async def list_products() -> list[dict]:
 async def add_to_cart(data: CartItem) -> Cart: ...
 
 
-@get("/internal/metrics", opt={"mcp_exclude": True})
+@get("/internal/metrics")  # unmarked — stays out of MCP
 async def metrics() -> dict: ...
 
 
@@ -284,8 +323,8 @@ app = Litestar(
 
 ## Official References
 
-- <https://docs.litestar-mcp.litestar.dev/>
-- <https://github.com/litestar-org/litestar-mcp>
+- <https://cofin.github.io/litestar-mcp/>
+- <https://github.com/cofin/litestar-mcp>
 - <https://modelcontextprotocol.io/>
 - <https://spec.modelcontextprotocol.io/>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "litestar-skills"
-version = "0.2.1"
+version = "0.3.0"
 description = "Opinionated first-party agent skills, plugins, subagents, slash commands, and MCP servers for the Litestar framework ecosystem"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -48,6 +48,7 @@ validation = [
   "flask>=3.0",        # advanced_alchemy.extensions.flask imports flask at module load
   "litestar[jinja,jwt]>=2.23",  # skill samples use 2.22/2.23 markers (FromQuery/JSONBody/NamedDependency/SkipValidation), litestar.plugins.jinja, and litestar.security.jwt
   "litestar-granian>=0.10",
+  "litestar-mcp>=0.7",  # litestar-mcp skill samples import LitestarMCP/MCPConfig/MCPAuthBackend/OIDCProviderConfig/mcp_prompt
   "litestar-saq>=0.5",
   "sanic[ext]>=24.6",  # advanced_alchemy.extensions.sanic imports sanic_ext at module load
   "sqlspec[adk,asyncpg,performance,psycopg]>=0.13",
@@ -154,7 +155,7 @@ exclude_lines = [
 # bump-my-version — atomic multi-manifest version sync
 # ============================================================
 [tool.bumpversion]
-current_version = "0.2.1"
+current_version = "0.3.0"
 commit = false
 tag = false
 tag_name = "v{new_version}"

--- a/skills/litestar-mcp/SKILL.md
+++ b/skills/litestar-mcp/SKILL.md
@@ -5,9 +5,9 @@ description: "Auto-activate for litestar_mcp, LitestarMCP, MCPConfig, MCPAuthCon
 
 # litestar-mcp
 
-`litestar-mcp` exposes explicitly marked Litestar route handlers as [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) tools and resources over MCP Streamable HTTP and JSON-RPC 2.0.
+`litestar-mcp` exposes explicitly marked Litestar route handlers as [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) tools, resources, and prompts over MCP Streamable HTTP and JSON-RPC 2.0.
 
-Mark routes with `mcp_tool="name"` or `mcp_resource="name"` directly on Litestar route decorators. Do not use the removed `@mcp_tool` / `@mcp_resource` decorator API or `opt={"mcp_tool_name": ...}` wrappers.
+Mark routes by passing `mcp_tool="name"`, `mcp_resource="name"`, or `mcp_prompt="name"` directly to the Litestar route decorator — Litestar funnels unknown kwargs into `handler.opt`, so no `opt={...}` wrapper is needed. The `@mcp_tool` / `@mcp_resource` / `@mcp_prompt` decorators (importable from `litestar_mcp`) still exist and are worth reaching for when you need the extra fields they expose — `output_schema`, `annotations`, `scopes`, `task_support`, prompt `arguments`. There is no `opt={"mcp_tool_name": ...}` form and no `mcp_exclude` key; neither is read. To hide a route, simply leave it unmarked (discovery is opt-in).
 
 ## Code Style Rules
 
@@ -58,10 +58,11 @@ The default MCP surface is:
 | Endpoint | Purpose |
 | --- | --- |
 | `GET /mcp` | Server-Sent Events stream when requested by the client |
-| `POST /mcp` | JSON-RPC endpoint for `initialize`, `ping`, `tools/*`, `resources/*`, and optional task methods |
+| `POST /mcp` | JSON-RPC endpoint for `initialize`, `ping`, `tools/*`, `resources/*`, `prompts/*`, `completion/complete`, and optional task methods |
+| `DELETE /mcp` | Terminate the current MCP session |
 | `GET /.well-known/mcp-server.json` | MCP server manifest |
 | `GET /.well-known/agent-card.json` | Agent card metadata |
-| `GET /.well-known/oauth-protected-resource` | OAuth protected-resource metadata when auth is configured |
+| `GET /.well-known/oauth-protected-resource` | OAuth protected-resource metadata (always registered; populated from `auth`) |
 
 ### MCPConfig
 
@@ -78,6 +79,14 @@ The default MCP surface is:
 | `exclude_tags` | `list[str] \| None` | `None` | Exclude routes with matching OpenAPI tags |
 | `auth` | `MCPAuthConfig \| None` | `None` | OAuth protected-resource metadata |
 | `tasks` | `bool \| MCPTaskConfig` | `False` | Enable experimental in-memory MCP task support |
+| `list_page_size` | `int` | `100` | Page size for `tools/list`, `resources/list`, `resources/templates/list`, `prompts/list` (clients page via opaque cursors) |
+| `opt_keys` | `MCPOptKeys` | `MCPOptKeys()` | Rename the `handler.opt` keys the plugin reads (e.g. to avoid collisions) |
+| `session_store` | `Store \| None` | `None` | Litestar `Store` backing MCP sessions; defaults to an in-memory store |
+| `session_max_idle_seconds` | `float` | `3600.0` | Idle timeout before an MCP session is evicted |
+| `sse_max_streams` | `int` | `10000` | Max concurrent SSE streams |
+| `sse_max_idle_seconds` | `float` | `3600.0` | Idle timeout for an SSE stream |
+
+> Filters (`include_tags` / `exclude_tags` / `include_operations` / `exclude_operations`) gate what is **advertised** in `tools/list` / `resources/list` / `prompts/list`. As of `litestar-mcp` 0.7.0 they do **not** gate `tools/call` / `resources/read` ([cofin/litestar-mcp#62](https://github.com/cofin/litestar-mcp/issues/62)), so they are an advertisement filter, not an access boundary — use `guards` / auth to actually restrict invocation.
 
 ### Route Marking
 
@@ -93,8 +102,34 @@ async def list_products() -> list[dict]: ...
 async def add_to_cart(data: CartItem) -> Cart: ...
 
 
-@get("/products/{product_id:int}", mcp_resource_template="shop://products/{product_id}")
+@get(
+    "/products/{product_id:int}",
+    mcp_resource="product",
+    mcp_resource_template="shop://products/{product_id}",
+)
 async def get_product(product_id: int) -> dict: ...
+
+
+@get("/products/{product_id:int}/blurb", mcp_prompt="product_blurb")
+async def product_blurb(product_id: int) -> str:
+    """Write a short marketing blurb for a product."""
+    ...
+```
+
+`mcp_resource_template` only takes effect alongside `mcp_resource` — the resource supplies the name the template binds to. A handler can expose more than one MCP role (a tool and a resource) at once; the description-override keys (`mcp_description` vs `mcp_resource_description`) are kind-specific so each surface can carry its own prose.
+
+Register prompts not bound to a route with the `@mcp_prompt` decorator plus `LitestarMCP(prompts=[...])`:
+
+```python
+from litestar_mcp import LitestarMCP, mcp_prompt
+
+
+@mcp_prompt("summarize", description="Summarize a document for the user.")
+def summarize(text: str) -> str:
+    return f"Summarize the following:\n\n{text}"
+
+
+app = Litestar(plugins=[LitestarMCP(prompts=[summarize])])
 ```
 
 Use structured metadata when the agent needs sharper tool selection:
@@ -110,12 +145,16 @@ Use structured metadata when the agent needs sharper tool selection:
 async def generate_report(data: ReportRequest) -> ReportQueued: ...
 ```
 
-### Excluding Routes
+### Hiding Routes
+
+Discovery is opt-in: a handler that carries no `mcp_*` marker never appears in MCP. There is no per-route exclude flag — `opt={"mcp_exclude": True}` is ignored.
 
 ```python
-@get("/internal/metrics", opt={"mcp_exclude": True})
+@get("/internal/metrics")  # unmarked — never exposed to MCP clients
 async def metrics() -> dict: ...
 ```
+
+To drop *marked* routes from discovery in bulk, use the `MCPConfig` filters (`exclude_tags` / `exclude_operations`, or an `include_tags` / `include_operations` allowlist). Remember these gate advertisement only ([cofin/litestar-mcp#62](https://github.com/cofin/litestar-mcp/issues/62)) — enforce real access control with `guards` or auth.
 
 ### JSON-RPC Call
 
@@ -191,7 +230,7 @@ pip install litestar-mcp
 
 ### Step 2: Decide What to Expose
 
-List only the routes that should be callable by AI clients. Mark those routes with `mcp_tool=`, `mcp_resource=`, or `mcp_resource_template=`. Do not rely on route method defaults.
+List only the routes that should be callable by AI clients. Mark those routes with `mcp_tool=`, `mcp_resource=`, or `mcp_prompt=` (add `mcp_resource_template=` next to `mcp_resource=` for templated resources). There are no method-based defaults — unmarked routes are never exposed.
 
 ### Step 3: Add the Plugin
 
@@ -212,7 +251,7 @@ Hit `POST /mcp` with `tools/list` and `resources/list`. Confirm only marked rout
 ## Guardrails
 
 - **Mark routes explicitly** - unmarked routes should not appear in MCP clients.
-- **Default to allowlists** - `include_tags` / `include_operations` prevent accidental exposure when route sets grow.
+- **Default to allowlists for discovery** - `include_tags` / `include_operations` keep the advertised tool set small as route counts grow, but they only filter discovery — pair them with `guards` / auth, which actually gate invocation.
 - **Never expose admin or destructive routes by default** - require a human-confirmation workflow before any irreversible operation.
 - **Prefer resources for read-only reference data** - agents may read resources speculatively.
 - **Keep DTOs precise** - loose `dict[str, Any]` request schemas produce weak tool contracts.
@@ -229,7 +268,7 @@ Before delivering an MCP integration, verify:
 
 - [ ] `LitestarMCP` is in `app.plugins`
 - [ ] Exposed routes use `mcp_tool=`, `mcp_resource=`, or `mcp_resource_template=`
-- [ ] Admin / internal routes use `opt={"mcp_exclude": True}` or are outside the allowlist
+- [ ] Admin / internal routes are left unmarked, or kept outside `include_*` / inside `exclude_*` — with `guards` or auth enforcing access
 - [ ] Auth is configured for the deployment boundary
 - [ ] `POST /mcp` `tools/list` returns only intended tools
 - [ ] `POST /mcp` `resources/list` includes only intended resources plus `litestar://openapi`
@@ -258,7 +297,7 @@ async def list_products() -> list[dict]:
 async def add_to_cart(data: CartItem) -> Cart: ...
 
 
-@get("/internal/metrics", opt={"mcp_exclude": True})
+@get("/internal/metrics")  # unmarked — stays out of MCP
 async def metrics() -> dict: ...
 
 
@@ -284,8 +323,8 @@ app = Litestar(
 
 ## Official References
 
-- <https://docs.litestar-mcp.litestar.dev/>
-- <https://github.com/litestar-org/litestar-mcp>
+- <https://cofin.github.io/litestar-mcp/>
+- <https://github.com/cofin/litestar-mcp>
 - <https://modelcontextprotocol.io/>
 - <https://spec.modelcontextprotocol.io/>
 

--- a/tools/check-upstream-imports.py
+++ b/tools/check-upstream-imports.py
@@ -56,6 +56,7 @@ TARGET_ROOTS: frozenset[str] = frozenset(
         "dishka",
         "litestar",
         "litestar_granian",
+        "litestar_mcp",
         "litestar_saq",
         "msgspec",
         "sqlalchemy",

--- a/tools/install.ps1
+++ b/tools/install.ps1
@@ -75,7 +75,7 @@ Set-StrictMode -Version Latest
 # =============================================================================
 # Constants
 # =============================================================================
-$script:Version = '0.2.1'
+$script:Version = '0.3.0'
 $script:RepoUrl = 'https://github.com/litestar-org/litestar-skills'
 $script:RepoSlug = 'litestar-org/litestar-skills'
 $script:MarketplaceName = 'litestar'

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -8,7 +8,7 @@
 #
 # Usage:
 #   tools/install.sh [--dry-run] [--force] [--only <host>] [--skip <host>]
-#   curl -fsSL https://raw.githubusercontent.com/litestar-org/litestar-skills/v0.2.1/tools/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/litestar-org/litestar-skills/v0.3.0/tools/install.sh | bash
 #
 # Hosts:
 #   claude     Claude Code        (prints instructions + optional settings edit)
@@ -20,7 +20,7 @@
 
 set -euo pipefail
 
-VERSION="0.2.1"
+VERSION="0.3.0"
 REPO_URL="https://github.com/litestar-org/litestar-skills"
 REPO_SLUG="litestar-org/litestar-skills"
 MARKETPLACE_NAME="litestar"

--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-VERSION="0.2.1"
+VERSION="0.3.0"
 PLUGIN_NAME="litestar"
 REPO_SLUG="litestar-org/litestar-skills"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1413,6 +1413,20 @@ wheels = [
 ]
 
 [[package]]
+name = "litestar-mcp"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "litestar", extra = ["jwt"] },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/30/83febd2e92fce22d8ab79423dda6ee6d8abfaeaea9d09126ed900ed16d93/litestar_mcp-0.7.0.tar.gz", hash = "sha256:3166c05380d97b9287f3b6019b3699d5aea0102910f908bfa2186838639bc7ca", size = 538275, upload-time = "2026-06-07T15:45:58.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/03/10e602456c18fc36a20efc9caabd68567bcaf04f79bc8ae6a24538c0bda2/litestar_mcp-0.7.0-py3-none-any.whl", hash = "sha256:39ba575932057770e5471690c23a97f39e538478cf0e839e4b4ba24567c8c751", size = 81309, upload-time = "2026-06-07T15:45:57.513Z" },
+]
+
+[[package]]
 name = "litestar-saq"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1427,7 +1441,7 @@ wheels = [
 
 [[package]]
 name = "litestar-skills"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -1449,6 +1463,7 @@ validation = [
     { name = "flask" },
     { name = "litestar", extra = ["jinja", "jwt"] },
     { name = "litestar-granian" },
+    { name = "litestar-mcp" },
     { name = "litestar-saq" },
     { name = "pytest-databases" },
     { name = "sanic", extra = ["ext"] },
@@ -1464,6 +1479,7 @@ requires-dist = [
     { name = "flask", marker = "extra == 'validation'", specifier = ">=3.0" },
     { name = "litestar", extras = ["jinja", "jwt"], marker = "extra == 'validation'", specifier = ">=2.23" },
     { name = "litestar-granian", marker = "extra == 'validation'", specifier = ">=0.10" },
+    { name = "litestar-mcp", marker = "extra == 'validation'", specifier = ">=0.7" },
     { name = "litestar-saq", marker = "extra == 'validation'", specifier = ">=0.5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.380" },


### PR DESCRIPTION
## Why

The `litestar-mcp` skill had drifted from the shipped library. #8 was filed against `litestar-mcp==0.4.0`; the library is now `0.7.0`, which reworked the public surface (prompts, configurable opt keys, sessions/SSE config, working tag/operation filters). This pass audits every claim against the 0.7.0 source and fixes the inaccuracies.

## Skill corrections (verified against litestar-mcp 0.7.0)

- **Route marking** — `mcp_tool=` / `mcp_resource=` / `mcp_prompt=` kwargs. The `@mcp_tool` / `@mcp_resource` / `@mcp_prompt` decorators were described as "removed" — they still exist (exported from `litestar_mcp`) and are now documented for the extra fields they carry (`output_schema`, `annotations`, `scopes`, `task_support`, prompt `arguments`).
- **Dropped non-functional forms** — `opt={"mcp_exclude": True}` and `opt={"mcp_tool_name": ...}` are not read by discovery. Discovery is opt-in, so an unmarked route is already hidden; bulk-hide marked routes with `include`/`exclude` tags/operations.
- **Filter semantics** — those filters gate **discovery** (`tools/list`, `resources/list`, `prompts/list`) but not **invocation** (`tools/call`, `resources/read`), so they are an advertisement filter, not an access boundary. Guardrails now point users to `guards`/auth for real access control.
- **`mcp_resource_template`** only binds alongside `mcp_resource` (it needs the resource name) — the previous template-only example silently registered nothing.
- **New 0.7.0 surface** — prompts (`mcp_prompt=`, `@mcp_prompt`, `LitestarMCP(prompts=[...])`, `prompts/list` + `prompts/get`), new `MCPConfig` fields (`list_page_size`, `opt_keys`, `session_store`, `sse_*`), and the `DELETE /mcp` and `prompts/*` endpoints.
- **Dead links** — docs → `cofin.github.io/litestar-mcp`, repo → `cofin/litestar-mcp` (the old `litestar-org/litestar-mcp` and `docs.litestar-mcp.litestar.dev` no longer resolve).

## Regression gate

Wired `litestar-mcp` into the upstream-import check (added to the `validation` extra and `TARGET_ROOTS`), so every `from litestar_mcp import …` in the skill is now verified against the installed library on `make check`. This is the same drift class as #8 — it now fails CI instead of shipping.

## Upstream bug filed

The discovery-only filter behavior is a genuine inconsistency in the library, filed separately at **cofin/litestar-mcp#62** (filtered tools/resources remain invokable). The skill documents the current behavior and links the issue.

## Verification

- `make check` green (lint, type-check, validators, skill-sample import gate now covering `litestar_mcp`).
- Codex package mirror regenerated; `make codex-package-check` passes.
- Version bumped `0.2.1 → 0.3.0`.

Closes #8.