### PR TITLE
feat: refresh Litestar ecosystem skills for v0.5.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -14,7 +14,7 @@
   "plugins": [
     {
       "name": "litestar",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "description": "Opinionated first-party agent skills, plugins, subagents, slash commands, and MCP servers for the Litestar framework ecosystem",
       "source": { "source": "local", "path": "./plugins/litestar" },
       "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "litestar",
       "source": "./",
       "description": "Opinionated first-party agent skills, plugins, subagents, slash commands, and MCP servers for the Litestar framework ecosystem",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "author": {
         "name": "Cody Fincher",
         "email": "cofin@litestar.dev"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "litestar",
   "description": "Opinionated first-party agent skills, plugins, subagents, slash commands, and MCP servers for the Litestar framework ecosystem",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "Cody Fincher",
     "email": "cofin@litestar.dev"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "litestar",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Opinionated first-party agent skills for the Litestar framework ecosystem",
   "author": {
     "name": "Cody Fincher",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "litestar",
   "displayName": "Litestar",
   "description": "Opinionated first-party agent skills, plugins, subagents, slash commands, and MCP servers for the Litestar framework ecosystem",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "Cody Fincher",
     "email": "cofin@litestar.dev"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         args: [--maxkb=500]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.18
+    rev: v0.15.20
     hooks:
       - id: ruff
         args: [--fix]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Status
 
-**v0.4.0 — early access.** Multi-host plumbing, 28 skills, ~28,500 lines of canonical content. Full launch-skill catalog growing.
+**v0.5.0 — early access.** Multi-host plumbing, 29 skills, ~28,500 lines of canonical content. Full launch-skill catalog growing.
 
 **Breaking host identity note:** host-facing marketplace, plugin, extension, managed-config, and skill namespace IDs are `litestar`. Existing installs under `litestar-skills` should be removed and reinstalled; no alias is shipped. The Python package and repository remain `litestar-skills`.
 
@@ -268,7 +268,7 @@ Per-host uninstall:
 
 ## What's In This Repo
 
-28 skills, focused references, ~28,500+ lines of canonical content:
+29 skills, focused references, ~28,500+ lines of canonical content:
 
 | Category | Skills |
 | --- | --- |
@@ -277,7 +277,7 @@ Per-host uninstall:
 | Foundation | `litestar-styleguide` |
 | Data | `advanced-alchemy`, `sqlspec`, `msgspec` |
 | Server | `litestar-granian` |
-| Tasks | `litestar-saq` |
+| Tasks | `litestar-saq`, `litestar-queues` |
 | Frontend | `litestar-vite`, `litestar-inertia`, `litestar-htmx` |
 | Integrations | `litestar-mcp`, `litestar-email` |
 | Packaging | `litestar-build` |

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "litestar-skills",
       "devDependencies": {
         "markdownlint-cli2": "^0.22.1",
-        "oxlint": "^1.68.0",
+        "oxlint": "^1.71.0",
       },
     },
   },
@@ -17,43 +17,43 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.71.0", "", { "os": "android", "cpu": "arm" }, "sha512-ImGmd1njEg4FEJH03jhRnveEegtO3czCtfptvaHivKAZQIYATbVFBrrzbaYMYv0oJioTnxZAZVSyV+oL7W8S2g=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.72.0", "", { "os": "android", "cpu": "arm" }, "sha512-zhCmvn+1Mj3UchAc/90i99S0t7jJUsHmFVSPg4UWrjO8b8eaSGwscgO6QAUtvHBstkjQwBttQNswEnAF1mIQdA=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.71.0", "", { "os": "android", "cpu": "arm64" }, "sha512-4A5BEexBrwY1YFF8Kiq/lp/wQPRG79G3BWIE1FuWaM5MvmpYSd+7ZySVcKkHdwo0UDzdQGddp6pD9mpctMqLnw=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.72.0", "", { "os": "android", "cpu": "arm64" }, "sha512-mtH+aY/ozv1eZoCUC2owjFAtyNBKHpJHygKeEu9zXXnQGW1Q2/qOpvx+I+Lf23+TvTz66F4iiXUbl2cGvoLPCQ=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.71.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9wJA9GJulLwS2usU3CEisI/ESDO1n1z9eyTCvApMDrAkbJ1ve0mORgTMjcWWsKxkzkeZ2N/Gpra5IQE7x8tYgQ=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.72.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-EvnajNPDtfknB3ZieeOOyDTwJn9QXDiwfnF4ZDQqART6RG6hjY4WigQcZdGoK2dkB3e1vrmEzN9aYbQCUkh/gQ=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.71.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-PlLCjS06V0PeJMAJwzjrExw1sYNW9Gch3JtNlcwwZDXGlTYDuwHNN89zYH8LTXFfgkVtsYvs2nv0FqrzyuFDzg=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.72.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZkCdEa/G80A7vEHfeCDz/+L3m33DE73v32mDKhgOIgz8Uwf0DFcK7+uu6qC+7LEhmz5fpOe1osWKyjSNMydFIQ=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.71.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-Lhil7bWre0ncxbUoDoxfS0JzpTz17BRQKW7iwoAUY8GJ66+WwJEfYPCFJ1P0WgVZR5/O/b3Q2pENlHOjeXLOGQ=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.72.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-NroXv2vh+sxVY1uya/rM5pjhx1hm8BzlYpx9q67QP0Xhw5MH2bf5GJylpvLEC+781p1Xli/317EoV9AlGwViag=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.71.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Oo9/L58PYD3RC0x05d2upAPLllHytTjHQGsnC06P6Ynn7jKkp5mdImQxXdJ3+FnBaKspNpGogzgVsi6g872LiA=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.72.0", "", { "os": "linux", "cpu": "arm" }, "sha512-0NDywYgfj279Ou/BcQuCYSj7NJwBfmWn5qc5uGO/Ny7fUWmXyIpvawqX/8acQlWG6IXelJsJhj+JAy6sjsKj0A=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.71.0", "", { "os": "linux", "cpu": "arm" }, "sha512-mSHfyfgJrEbyIR29ejaeS50BdPk+GoNPlC1dckpDiUZbJAIel68sjSMdOt4WY0/gva+ECC7FNITQkxMJU+vSBw=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.72.0", "", { "os": "linux", "cpu": "arm" }, "sha512-4vpXB06h65Ezsy4hRyrGjGrfa1SkVPii09yaajiYhmVpgsFiLD+KNxIx/BNAY+XiO+i1yqp9HHdwqM8VTqa5XQ=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.71.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-n9yY4M2tiy3aij4AqtlnspzpfdpeT5JQfK2/w2d8oyp5W0FRwOb1dIeX99nORNcxGr08iD9bH8N5XFz3I2iy8w=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.72.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-immaN4g2ZGFiOkKrvRX9LvzZdd2GkQM5wR+UyzYyUuyhUTXGQ4HKUJH18xp4G8OfhCVaVAJfKZxwE1r8+4hhaQ=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.71.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-fJZrs5sDZtTaPIOiemRQQmo82Ezy+vOGXemPc4Ok7iVVsYsFa7SlW6Z5XN819VfsqBHRm3NJ3rTdnR8+bJYJdQ=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.72.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-JGHS9Mnr7iWyyLDxgCv1MhzVpAckgptg00F2gnxt/GD7lQ2SW1BRcxHqhSTaSdDpjWRrBkBxMMh4+Hn3aVtExg=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.71.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-cwl7VKGERIy9p+G+AvZdfy/06q0aHXaTt/mMRReC751iuNYJgqKjB7NydXSS30nBT9vtr2tunciOtrR4fD6FUA=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.72.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-AOYgBZqxNshrg83P9v0RYv+m8s10Cqkj4/PxXFDhcS3k7FqsIG5+CxErshZCIN7G8iy4Y+VGfAsuEdar8AcbBg=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.71.0", "", { "os": "linux", "cpu": "none" }, "sha512-eZ8ieVXvzGi8jr7+ybQGPK2STw3mldfxZlgA2738iflfB/rzA69sE6m5rDRpQaxC7dpm745Enlh1Tod0QAk9Gg=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.72.0", "", { "os": "linux", "cpu": "none" }, "sha512-QMybPS5ij3/vrKG67mqzHwW++91sYxK/PPUVi6SBtNCEzW4niS52fVBdXbQ6nou0wWbUPEpx8Sl/ZjtgE3clXA=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.71.0", "", { "os": "linux", "cpu": "none" }, "sha512-puMDbQYe6+NXwfMusojoA7CXGn2b3utukmd23PQqc1E3XhVCwyZ+FueSMzDYeNgDV2dUfIVXAAKZBcFDeCL6sA=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.72.0", "", { "os": "linux", "cpu": "none" }, "sha512-gOc3W7JV0PXRpIL7stUlLe3Wa9Gp0Kdlup87IT3gHDvPKck2xNgMIl/Gs2lldYY2lyXZDC4rWi3hmoLUobkgbQ=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.71.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-4NJLxBs1ujISCt3L/1FcywLs73PWtJuw+piD6feK2V6h6OS6P7xu9/sWt1DTRLibe6QCzmfZzmM/2HPORoV/Lg=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.72.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-rpGxph+FjjHcYI5q6uxB3Az+tnfmEnDbSA8+PK9ZE/VzyUAkvBOMeuY7ZQMhu5mpZH7YQDsTdW6Cx4kV/msc6w=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.71.0", "", { "os": "linux", "cpu": "x64" }, "sha512-cFDaiR8L3430qp88tfZnvFlt3KotFhR/DlbIL0nHOMMYiG/9Wy4l+6f7t8G8pTa9bd8Lt8+M0y/qjRQ/xcB74g=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.72.0", "", { "os": "linux", "cpu": "x64" }, "sha512-WND+uhf/Ko13SLqQMWQUgsZuLvYYEvL0ZKgg0tgGYfLqxG7l8Ju123fHDMJyYSDl5E3bUbpFUuii/OvMreFQzw=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.71.0", "", { "os": "linux", "cpu": "x64" }, "sha512-orfixdt76KlpNly9z0PkWBBNfwjKz+JFVLP/7wnVchlKNU9Dpt9InU/ZggeSej6fC7qwHmHNOGlhLnQXcYoGuA=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.72.0", "", { "os": "linux", "cpu": "x64" }, "sha512-SrpbrUL70nG9vh6zP4/oKHWgLuHquwsr7MW9XOn0olBVgh10Uqr8qscKhQoBGEn6olK/IUpn5GSKcdQ5AjUhGA=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.71.0", "", { "os": "none", "cpu": "arm64" }, "sha512-9emQu2lAp6yhPB3XuI+++vR+l/o6JR1X+EpxwcumPdQXBWXEPAsquPGL7l158EqU8SebQMXTUa/S5zN98juyHw=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.72.0", "", { "os": "none", "cpu": "arm64" }, "sha512-qkrsEn6NmgFKr7U/QnezQMb+q/vzAy0Dd9Y95gQGQTyjzDLN+HRZMuM5u70iyH4nBLCfKBzhjMsYCehKay2jyg=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.71.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-bd5kI8spYwTm3BILDtGhi73zoup5dw8MlPQNT8YB3BD5UIsjNe3K9/4ctrzQMX4SZMoK5HgzVLkLJzacEXB7fA=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.72.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-LWR6ZlFZph+KPjXv8opgZsXRDCdrdQe8VL8Cg9zxCoBS73h6znzZpydVgmdnwj8mB9AuSM5jxEgDJDpQkjboeg=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.71.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-W4HvOHGzVLHcrmFu+bMrJlho+/yrlX5ZNdJZqGe8MEldkQG+RHYhxxad9P4jvWAYFmIqUA5i9DQ8QsJqSU9GIw=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.72.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-yt6HEh7IsHvtjRWtmeZRX134eaXKHq5Gnqlf1xBJdJl1JtdoRUEJw3nAxpZoUDS860cX/foKbztO441anVBtVQ=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.71.0", "", { "os": "win32", "cpu": "x64" }, "sha512-D2kyEIPHk/G/wiZLnwTVC/sVst+T/lKldVOjAFpgTIBUAOlry72e5OiapDbDBF4LfJLkN5ypJb/8Eu6yJzkveQ=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.72.0", "", { "os": "win32", "cpu": "x64" }, "sha512-b2eKFD2hX7tIwmo/cyH6TDq8vzWRZ2qNHrzoGntUTmq0h3zQh/uX3eTSHCwI8OB/ADQfJCRelLItK8BsxuucDA=="],
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
@@ -195,7 +195,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "oxlint": ["oxlint@1.71.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.71.0", "@oxlint/binding-android-arm64": "1.71.0", "@oxlint/binding-darwin-arm64": "1.71.0", "@oxlint/binding-darwin-x64": "1.71.0", "@oxlint/binding-freebsd-x64": "1.71.0", "@oxlint/binding-linux-arm-gnueabihf": "1.71.0", "@oxlint/binding-linux-arm-musleabihf": "1.71.0", "@oxlint/binding-linux-arm64-gnu": "1.71.0", "@oxlint/binding-linux-arm64-musl": "1.71.0", "@oxlint/binding-linux-ppc64-gnu": "1.71.0", "@oxlint/binding-linux-riscv64-gnu": "1.71.0", "@oxlint/binding-linux-riscv64-musl": "1.71.0", "@oxlint/binding-linux-s390x-gnu": "1.71.0", "@oxlint/binding-linux-x64-gnu": "1.71.0", "@oxlint/binding-linux-x64-musl": "1.71.0", "@oxlint/binding-openharmony-arm64": "1.71.0", "@oxlint/binding-win32-arm64-msvc": "1.71.0", "@oxlint/binding-win32-ia32-msvc": "1.71.0", "@oxlint/binding-win32-x64-msvc": "1.71.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-U1m1X+C0vDj7DC1e13IoZULzEcPczE7UOMTs8VlZGHUEIUaSTZKo5qkPsQEfzpgnQ29Pea/w3Xntk62UCecxZw=="],
+    "oxlint": ["oxlint@1.72.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.72.0", "@oxlint/binding-android-arm64": "1.72.0", "@oxlint/binding-darwin-arm64": "1.72.0", "@oxlint/binding-darwin-x64": "1.72.0", "@oxlint/binding-freebsd-x64": "1.72.0", "@oxlint/binding-linux-arm-gnueabihf": "1.72.0", "@oxlint/binding-linux-arm-musleabihf": "1.72.0", "@oxlint/binding-linux-arm64-gnu": "1.72.0", "@oxlint/binding-linux-arm64-musl": "1.72.0", "@oxlint/binding-linux-ppc64-gnu": "1.72.0", "@oxlint/binding-linux-riscv64-gnu": "1.72.0", "@oxlint/binding-linux-riscv64-musl": "1.72.0", "@oxlint/binding-linux-s390x-gnu": "1.72.0", "@oxlint/binding-linux-x64-gnu": "1.72.0", "@oxlint/binding-linux-x64-musl": "1.72.0", "@oxlint/binding-openharmony-arm64": "1.72.0", "@oxlint/binding-win32-arm64-msvc": "1.72.0", "@oxlint/binding-win32-ia32-msvc": "1.72.0", "@oxlint/binding-win32-x64-msvc": "1.72.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-1rhdZIP/EvoI91ABIwNU5Q8+bWf8mjrS5UzIOZld4d4bXxJvtlUhlQvaoTogIGin/qdErMOrwaIJvCSIAKTLhA=="],
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 

--- a/hooks/lib/skill-map.json
+++ b/hooks/lib/skill-map.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "version": "1",
-  "static_intro": "litestar loaded. Prefer first-party Litestar patterns. Skills are namespaced as `litestar:<name>`. Available: litestar, litestar-routing, litestar-dto-openapi, litestar-auth-guards, litestar-di, litestar-data-services, litestar-settings, litestar-exceptions, litestar-middleware, litestar-plugins, litestar-realtime, litestar-ai-serving, sqlspec, advanced-alchemy, msgspec, litestar-granian, litestar-saq, litestar-vite, litestar-htmx, litestar-inertia, litestar-mcp, litestar-email, litestar-testing, pytest-databases, polyfactory, litestar-build, litestar-deployment, litestar-styleguide.",
+  "static_intro": "litestar loaded. Prefer first-party Litestar patterns. Skills are namespaced as `litestar:<name>`. Available: litestar, litestar-routing, litestar-dto-openapi, litestar-auth-guards, litestar-di, litestar-data-services, litestar-settings, litestar-exceptions, litestar-middleware, litestar-plugins, litestar-realtime, litestar-ai-serving, sqlspec, advanced-alchemy, msgspec, litestar-granian, litestar-saq, litestar-queues, litestar-vite, litestar-htmx, litestar-inertia, litestar-mcp, litestar-email, litestar-testing, pytest-databases, polyfactory, litestar-build, litestar-deployment, litestar-styleguide.",
   "matchers": [
     {
       "skill": "litestar",
@@ -158,6 +158,15 @@
         { "type": "python_import", "module": "litestar_saq" }
       ],
       "reminder": "Project uses litestar-saq. Use the `litestar:litestar-saq` skill for SAQPlugin / SAQConfig / QueueConfig: background tasks, cron jobs, and the `litestar workers run` CLI."
+    },
+    {
+      "skill": "litestar-queues",
+      "priority": 70,
+      "signals": [
+        { "type": "pyproject_dep", "name": "litestar-queues" },
+        { "type": "python_import", "module": "litestar_queues" }
+      ],
+      "reminder": "Project uses litestar-queues. Use the `litestar:litestar-queues` skill for queue app wiring, broker/back-end selection, workers, tasks, and schedules."
     },
     {
       "skill": "litestar-vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "litestar-skills",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Opinionated first-party agent skills, plugins, subagents, slash commands, and MCP servers for the Litestar framework ecosystem",
   "main": ".opencode/plugins/litestar.js",
   "type": "module",
@@ -28,7 +28,7 @@
   ],
   "devDependencies": {
     "markdownlint-cli2": "^0.22.1",
-    "oxlint": "^1.71.0"
+    "oxlint": "^1.72.0"
   },
   "scripts": {
     "lint:js": "oxlint",

--- a/plugins/litestar/.codex-plugin/plugin.json
+++ b/plugins/litestar/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "litestar",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Opinionated first-party agent skills for the Litestar framework ecosystem",
   "author": {
     "name": "Cody Fincher",

--- a/plugins/litestar/hooks/lib/skill-map.json
+++ b/plugins/litestar/hooks/lib/skill-map.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "version": "1",
-  "static_intro": "litestar loaded. Prefer first-party Litestar patterns. Skills are namespaced as `litestar:<name>`. Available: litestar, litestar-routing, litestar-dto-openapi, litestar-auth-guards, litestar-di, litestar-data-services, litestar-settings, litestar-exceptions, litestar-middleware, litestar-plugins, litestar-realtime, litestar-ai-serving, sqlspec, advanced-alchemy, msgspec, litestar-granian, litestar-saq, litestar-vite, litestar-htmx, litestar-inertia, litestar-mcp, litestar-email, litestar-testing, pytest-databases, polyfactory, litestar-build, litestar-deployment, litestar-styleguide.",
+  "static_intro": "litestar loaded. Prefer first-party Litestar patterns. Skills are namespaced as `litestar:<name>`. Available: litestar, litestar-routing, litestar-dto-openapi, litestar-auth-guards, litestar-di, litestar-data-services, litestar-settings, litestar-exceptions, litestar-middleware, litestar-plugins, litestar-realtime, litestar-ai-serving, sqlspec, advanced-alchemy, msgspec, litestar-granian, litestar-saq, litestar-queues, litestar-vite, litestar-htmx, litestar-inertia, litestar-mcp, litestar-email, litestar-testing, pytest-databases, polyfactory, litestar-build, litestar-deployment, litestar-styleguide.",
   "matchers": [
     {
       "skill": "litestar",
@@ -158,6 +158,15 @@
         { "type": "python_import", "module": "litestar_saq" }
       ],
       "reminder": "Project uses litestar-saq. Use the `litestar:litestar-saq` skill for SAQPlugin / SAQConfig / QueueConfig: background tasks, cron jobs, and the `litestar workers run` CLI."
+    },
+    {
+      "skill": "litestar-queues",
+      "priority": 70,
+      "signals": [
+        { "type": "pyproject_dep", "name": "litestar-queues" },
+        { "type": "python_import", "module": "litestar_queues" }
+      ],
+      "reminder": "Project uses litestar-queues. Use the `litestar:litestar-queues` skill for queue app wiring, broker/back-end selection, workers, tasks, and schedules."
     },
     {
       "skill": "litestar-vite",

--- a/plugins/litestar/skills/advanced-alchemy/SKILL.md
+++ b/plugins/litestar/skills/advanced-alchemy/SKILL.md
@@ -27,7 +27,7 @@ Advanced Alchemy is NOT a raw ORM — it is a **service/repository layer** built
 - **Repository pattern** for type-safe async CRUD
 - **Service layer** with lifecycle hooks (`to_model_on_create`, `to_model_on_update`)
 - **Framework plugins** for automatic session/transaction management
-- **Custom types**: `EncryptedString`, `FileObject`, `DateTimeUTC`, `GUID`
+- **Custom types**: `EncryptedString`, `FileObject`, `DateTimeUTC`, `GUID`, `Bool`, `Vector`, `TOTPSecret`, `OneTimeCode`
 - **Alembic integration** for migrations via CLI
 
 ## Quick Reference
@@ -69,13 +69,16 @@ Key lifecycle hooks: `to_model_on_create`, `to_model_on_update`, `to_model_on_up
 | `EncryptedString` | Transparent AES encryption at rest | Requires `ENCRYPTION_KEY` in config |
 | `UUID6` / `UUID7` | Time-sortable UUID variants | UUID7 preferred — monotonic ordering with millisecond timestamp prefix |
 | `DateTimeUTC` | Timezone-aware UTC datetime | Stores as UTC; raises on naive datetimes |
+| `Bool` | Dialect-aware boolean | Uses Oracle 23c native `BOOLEAN` when SQLAlchemy exposes it; falls back to stock SQLAlchemy `Boolean` |
+| `Vector` | Dialect-aware vector storage and distance operators | Oracle 23ai `VECTOR`, PostgreSQL/CockroachDB `pgvector`, JSON fallback without distance operators |
+| `TOTPSecret` / `OneTimeCode` | MFA and single-use code storage | `TOTPSecret` encrypts shared secrets; `OneTimeCode` hashes codes and requires an explicit hashing backend |
 
 ## Repository Service Layer
 
 `SQLAlchemyAsyncRepositoryService` is the primary service base class. Key behaviors:
 
 - **Dict-to-model conversion**: pass raw `dict` to `create()`, `update()`, `upsert()` — the service converts via `to_model_on_create` / `to_model_on_update` lifecycle hooks before persistence
-- **Bulk operations**: `create_many(data)`, `update_many(data)`, `upsert_many(data)`, `delete_many(item_ids)` — batched in a single transaction; prefer over calling single-row methods in a loop
+- **Bulk operations**: `create_many(data)`, `update_many(data)`, `upsert_many(data)`, `delete_many(item_ids)` — batched in a single transaction; `delete_many()` accepts raw primary keys, composite-key tuples/dicts, model instances, or mixed lists
 - **Lifecycle hooks**: `to_model_on_create`, `to_model_on_update`, `to_model_on_upsert` — override to transform input data, hash passwords, normalize strings, etc.
 
 ## Mixins
@@ -139,7 +142,7 @@ Run `alembic revision --autogenerate -m "description"` to create the migration, 
 - **Repositories are for data access only** — no business rules, no side effects beyond database operations
 - **Never bypass the service layer** to call repository methods directly from handlers
 - **Always set `match_fields`** on services that use `upsert()` to avoid duplicate-key errors
-- **Use `schema_dump()` to convert DTOs** (Pydantic/msgspec/attrs) before passing to service methods
+- **Use `schema_dump()` / `schema_dump_config` for explicit dump behavior** — services already convert Pydantic/msgspec/attrs/dataclass inputs during model conversion
 - **Prefer `UUIDAuditBase`** as default base class — only deviate when you have a concrete reason
 - **Use `advanced_alchemy.*` imports** — the old `litestar.plugins.sqlalchemy` paths are deprecated
 - **Model modules avoid `from __future__ import annotations`** — SQLAlchemy 2.0 needs the real `Mapped[...]` type at class-creation time. Consumer modules (handlers, services, tests) MAY use it.

--- a/plugins/litestar/skills/advanced-alchemy/references/fastapi-integration.md
+++ b/plugins/litestar/skills/advanced-alchemy/references/fastapi-integration.md
@@ -1,6 +1,6 @@
 # FastAPI integration
 
-This guide covers wiring Advanced Alchemy into a FastAPI application: the `Depends`-based DI pattern, the `provide_service` and `provide_filters` helpers, and the `alchemy database` CLI shim that ships with the FastAPI extension. Routing note: this guide covers FastAPI. For plain Starlette without `Depends`, see [starlette-integration.md](starlette-integration.md). For Flask (WSGI), see [flask-integration.md](flask-integration.md). For Sanic, see [sanic-integration.md](sanic-integration.md).
+This guide covers wiring Advanced Alchemy into a FastAPI application: the `Depends`-based DI pattern, the `provide_service` and `provide_filters` helpers, and the `database` / `db` CLI shim that ships with the FastAPI extension. Routing note: this guide covers FastAPI. For plain Starlette without `Depends`, see [starlette-integration.md](starlette-integration.md). For Flask (WSGI), see [flask-integration.md](flask-integration.md). For Sanic, see [sanic-integration.md](sanic-integration.md).
 
 ## Install
 
@@ -8,7 +8,7 @@ This guide covers wiring Advanced Alchemy into a FastAPI application: the `Depen
 pip install 'advanced-alchemy[fastapi]'
 ```
 
-This pulls FastAPI, Starlette (FastAPI's ASGI substrate), and the core Advanced Alchemy library. The async SQLAlchemy driver (`asyncpg`, `aiosqlite`, `asyncmy`, etc.) is installed separately. If you want the `alchemy` CLI integrated with `fastapi dev` / `fastapi run`, also install `fastapi[standard]` so `fastapi_cli` is available.
+This pulls FastAPI, Starlette (FastAPI's ASGI substrate), and the core Advanced Alchemy library. The async SQLAlchemy driver (`asyncpg`, `aiosqlite`, `asyncmy`, etc.) is installed separately. If you want the database CLI integrated with `fastapi dev` / `fastapi run`, also install `fastapi[standard]` so `fastapi_cli` is available.
 
 ## Entry point
 
@@ -238,7 +238,7 @@ The FastAPI extension ships a Click command group that wraps the Alembic CLI. Tw
 
 ### Via the FastAPI CLI (`fastapi dev` / `fastapi run`)
 
-If you have `fastapi_cli` installed (through the `fastapi[standard]` extra), call `assign_cli_group(app)` from your app module. This adds an `alchemy database` subcommand to the `fastapi` CLI:
+If you have `fastapi_cli` installed (through the `fastapi[standard]` extra), call `assign_cli_group(app)` from your app module. This registers Typer-native `database` and `db` commands on the FastAPI CLI and forwards to the Advanced Alchemy Click migration group. Use this Typer 0.26-compatible path; do not attach the Click group directly to Typer.
 
 ```python
 from advanced_alchemy.extensions.fastapi import AdvancedAlchemy, assign_cli_group
@@ -257,18 +257,19 @@ fastapi dev app.py database revision --autogenerate -m "add orders table"
 
 ### As a standalone Click entry point
 
-Alternatively, wire the command group into your own `__main__` using `register_database_commands(app)`:
+Alternatively, wire the command group into your own Click `__main__` using `register_database_commands(app)`:
 
 ```python
 if __name__ == "__main__":
-    from fastapi_cli.cli import app as fastapi_cli_app
-    from typer.main import get_group
-
     from advanced_alchemy.extensions.fastapi.cli import register_database_commands
+    from advanced_alchemy.utils.cli_tools import click
 
-    click_app = get_group(fastapi_cli_app)
-    click_app.add_command(register_database_commands(app))
-    click_app()
+    @click.group()
+    def cli() -> None:
+        """Application CLI."""
+
+    cli.add_command(register_database_commands(app))
+    cli()
 ```
 
 Then `python app.py database upgrade head` works without FastAPI's own CLI entry point.
@@ -401,5 +402,5 @@ One POST to `/orders` with `{"customer_email": "a@b.co", "total_cents": 9900}`:
 - [sanic-integration.md](sanic-integration.md) — `request.ctx`-based equivalent.
 - [services.md](services.md) — `SQLAlchemyAsyncRepositoryService` API.
 - [filters.md](filters.md) — the underlying filter types (`LimitOffset`, `SearchFilter`, etc.) that `provide_filters` assembles.
-- [migrations.md](migrations.md) — Alembic workflow behind `alchemy database`.
+- [migrations.md](migrations.md) — Alembic workflow behind the database CLI.
 - [../../litestar-styleguide/references/canonical-apps.md](../../litestar-styleguide/references/canonical-apps.md) — public reference apps (Litestar-based; service/repository code transfers directly).

--- a/plugins/litestar/skills/advanced-alchemy/references/services.md
+++ b/plugins/litestar/skills/advanced-alchemy/references/services.md
@@ -67,11 +67,14 @@ class UserService(SQLAlchemyAsyncRepositoryService[m.User]):
 ## Helper Utilities
 
 ```python
-from advanced_alchemy.service import schema_dump, is_dict_with_field, is_dict_without_field
+from advanced_alchemy.service import SchemaDumpConfig, schema_dump, is_dict_with_field, is_dict_without_field
 
 
 # Convert a Pydantic/msgspec/attrs schema to dict for service ingestion
 data = schema_dump(create_schema)
+
+# Tune dump behavior for partial updates or plain-object DTOs
+data = schema_dump(create_schema, config=SchemaDumpConfig(exclude_none=True))
 
 # Check dict shape before transforming
 if is_dict_with_field(data, "password"):
@@ -79,6 +82,27 @@ if is_dict_with_field(data, "password"):
 
 if is_dict_without_field(data, "slug"):
     data["slug"] = slugify(data["title"])
+```
+
+Set `schema_dump_config` on a service class to change the default conversion behavior for schema-like inputs. Pass `schema_dump_config=` to `create()`, `create_many()`, `update()`, `update_many()`, `upsert()`, `upsert_many()`, `get_or_upsert()`, or `get_and_update()` for a single operation.
+
+```python
+from advanced_alchemy.service import SchemaDumpConfig
+
+
+class UserService(SQLAlchemyAsyncRepositoryService[m.User]):
+    class Repo(SQLAlchemyAsyncRepository[m.User]):
+        model_type = m.User
+
+    repository_type = Repo
+    schema_dump_config = SchemaDumpConfig(exclude_unset=True, exclude_none=True)
+
+
+user = await service.update(
+    data=patch_schema,
+    item_id=user_id,
+    schema_dump_config=SchemaDumpConfig(exclude_none=True, exclude_defaults=True),
+)
 ```
 
 ## Common Service Operations
@@ -110,6 +134,7 @@ user = await service.upsert({"email": "test@example.com", "name": "Test"})
 
 # Delete
 await service.delete(user_id)
+await service.delete_many([user_id, user_model])  # raw IDs, model instances, and mixed lists are valid
 
 # Exists / Count
 exists = await service.exists(email="test@example.com")

--- a/plugins/litestar/skills/advanced-alchemy/references/types.md
+++ b/plugins/litestar/skills/advanced-alchemy/references/types.md
@@ -14,6 +14,10 @@ from advanced_alchemy.types import (
     BigIntIdentity,
     ORA_JSONB,
     PasswordHash,
+    Bool,
+    Vector,
+    TOTPSecret,
+    OneTimeCode,
 )
 from advanced_alchemy.types.file_object import FileObject, StoredObject
 ```
@@ -60,7 +64,7 @@ class Token(UUIDAuditBase):
 
 ## JsonB
 
-Cross-database JSONB type. Uses native `JSONB` on PostgreSQL (with indexing support). Falls back to standard `JSON` on other databases.
+Cross-database JSONB type. Uses native `JSONB` on PostgreSQL/CockroachDB (with indexing support). On Oracle, it routes through `ORA_JSONB`; other databases use standard `JSON`.
 
 ```python
 from advanced_alchemy.types import JsonB
@@ -72,14 +76,15 @@ class Config(UUIDAuditBase):
     tags: Mapped[list] = mapped_column(JsonB, default=list)
 ```
 
-- On PostgreSQL, supports GIN indexing for fast key/value lookups
-- On SQLite/MySQL, stores as JSON text
+- On PostgreSQL/CockroachDB, supports native JSONB indexing for fast key/value lookups.
+- On Oracle with SQLAlchemy 2.1+ and Oracle 21c+, stores as native `oracle.JSON`; otherwise uses BLOB binary JSON with an `IS JSON` check constraint.
+- On SQLite/MySQL, stores as standard `JSON`.
 
 ---
 
 ## ORA_JSONB
 
-Oracle-compatible JSONB type. Handles Oracle's specific JSON column semantics while remaining compatible with other databases.
+Oracle-compatible JSONB type. Uses native `sqlalchemy.dialects.oracle.JSON` on SQLAlchemy 2.1+ when the Oracle server is 21c or newer. Falls back to BLOB binary JSON with an `IS JSON` check constraint when native Oracle JSON is unavailable.
 
 ```python
 from advanced_alchemy.types import ORA_JSONB
@@ -90,8 +95,8 @@ class OracleModel(UUIDAuditBase):
     metadata_: Mapped[dict] = mapped_column(ORA_JSONB, default=dict)
 ```
 
-- Use when targeting Oracle as a primary or secondary database
-- Falls back to standard JSON behavior on non-Oracle backends
+- Use when targeting Oracle as a primary or secondary database.
+- Keep the fallback path in mind for SQLAlchemy 2.0.x, Oracle 19c, offline DDL, or first-connect flows without server version information.
 
 ---
 
@@ -307,7 +312,7 @@ if document.file:
 
 ## Bool (dialect-aware boolean)
 
-`Bool` (added 1.11) resolves to each dialect's native boolean, including Oracle 23c's real `BOOLEAN` (falling back to `NUMBER(1)` on older Oracle). Use it instead of `sqlalchemy.Boolean` when the model must run on Oracle as well as PostgreSQL/SQLite/MySQL.
+`Bool` (added 1.11) resolves to each dialect's stock boolean type, including Oracle 23c's real `BOOLEAN` when SQLAlchemy exposes `oracle.BOOLEAN`. Older Oracle versions and SQLAlchemy 2.0.x fall back to stock SQLAlchemy `Boolean`. Use it when a model must run on Oracle as well as PostgreSQL/SQLite/MySQL.
 
 ```python
 from advanced_alchemy.types import Bool
@@ -345,22 +350,28 @@ stmt = (
 
 ## TOTP and One-Time Codes
 
-Added in 1.11 for authentication flows. `TOTPSecret` is an `EncryptedString` subtype that stores a TOTP shared secret encrypted at rest; pair it with `TOTPProvider` / `generate_totp_secret` to issue and verify codes. `OneTimeCode` is the SQLAlchemy column type for single-use codes (email/SMS verification); loaded values expose the `HashedOneTimeCode` verification wrapper.
+Added in 1.11 for authentication flows. `TOTPSecret` is an `EncryptedString` subtype that stores a TOTP shared secret encrypted at rest; it requires `pyotp` and an explicit encryption key. Pair it with `TOTPProvider` / `generate_totp_secret` to issue and verify codes. `OneTimeCode` is the SQLAlchemy column type for single-use codes (email/SMS verification); it requires an explicit password-hashing backend and loaded values expose the `HashedOneTimeCode` verification wrapper.
 
 ```python
+from typing import Any
+
 from advanced_alchemy.types import (
     TOTPSecret,
     OneTimeCode,
     generate_totp_secret,
     generate_one_time_code,
 )
+from advanced_alchemy.types.password_hash.argon2 import Argon2Hasher
 from sqlalchemy.orm import Mapped, mapped_column
 
 
 class Account(UUIDBase):
     totp_secret: Mapped[str | None] = mapped_column(TOTPSecret(key=ENCRYPTION_KEY), default=None)
     # writes a plaintext code; the column hashes it. Loaded values verify through HashedOneTimeCode.
-    email_code: Mapped[str | None] = mapped_column(OneTimeCode, default=None)
+    email_code: Mapped[Any | None] = mapped_column(
+        OneTimeCode(backend=Argon2Hasher(), ttl_seconds=600, max_attempts=3),
+        default=None,
+    )
 ```
 
 ## Type Compatibility Matrix
@@ -369,12 +380,12 @@ class Account(UUIDBase):
 | --- | --- | --- | --- | --- |
 | `DateTimeUTC` | `TIMESTAMP WITH TIME ZONE` | `DATETIME` | `DATETIME` | `TIMESTAMP WITH TIME ZONE` |
 | `GUID` | `UUID` (native) | `CHAR(32)` / `BINARY(16)` | `CHAR(32)` / `BINARY(16)` | `RAW(16)` |
-| `JsonB` | `JSONB` (native) | `JSON` | `JSON` | `JSON` |
-| `ORA_JSONB` | `JSONB` | `JSON` | `JSON` | `JSON` (Oracle-optimized) |
+| `JsonB` | `JSONB` (native) | `JSON` | `JSON` | `oracle.JSON` on SQLAlchemy 2.1+ / Oracle 21c+; BLOB + check constraint fallback |
+| `ORA_JSONB` | `JSONB` | `JSON` | `JSON` | `oracle.JSON` on SQLAlchemy 2.1+ / Oracle 21c+; BLOB + check constraint fallback |
 | `BigIntIdentity` | `BIGSERIAL` | `INTEGER` | `BIGINT AUTO_INCREMENT` | `NUMBER(19)` |
 | `EncryptedString` | `VARCHAR` | `VARCHAR` | `VARCHAR` | `VARCHAR2` |
 | `EncryptedText` | `TEXT` | `TEXT` | `TEXT` | `CLOB` |
 | `PasswordHash` | `VARCHAR` | `VARCHAR` | `VARCHAR` | `VARCHAR2` |
 | `StoredObject` | `JSONB` | `JSON` | `JSON` | `JSON` |
-| `Bool` | `BOOLEAN` | `BOOLEAN` | `BOOL` | `BOOLEAN` (23c) / `NUMBER(1)` |
-| `Vector` | `pgvector` / JSON | `JSON` | `JSON` | `VECTOR` (23ai) / JSON |
+| `Bool` | `BOOLEAN` | `BOOLEAN` | `BOOL` | `BOOLEAN` on SQLAlchemy 2.1+ / Oracle 23c+; stock SQLAlchemy `Boolean` fallback |
+| `Vector` | `pgvector` / JSON | `JSON` | `JSON` | `VECTOR` |

--- a/plugins/litestar/skills/litestar-mcp/SKILL.md
+++ b/plugins/litestar/skills/litestar-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: litestar-mcp
-description: "Auto-activate for litestar_mcp, LitestarMCP, MCPConfig, MCPAuthConfig, MCPAuthBackend, mcp_tool=, mcp_resource=, Streamable HTTP, or OIDC MCP endpoints. Not for non-Litestar MCP."
+description: "Auto-activate for litestar_mcp, LitestarMCP, MCP, MCPConfig, mcp.app, mcp.run(), @mcp.tool/resource/prompt, MCPAuthConfig, MCPAuthBackend, mcp_tool=, mcp_resource=, Streamable HTTP, stdio, or OIDC MCP endpoints. Not for non-Litestar MCP."
 ---
 
 # litestar-mcp
@@ -13,7 +13,7 @@ Mark routes by passing `mcp_tool="name"`, `mcp_resource="name"`, or `mcp_prompt=
 
 - PEP 604 unions: `T | None`, never `Optional[T]`
 - Consumer Litestar app modules MAY use `from __future__ import annotations`
-- Async all I/O - handlers exposed through MCP must be `async def`
+- Async all I/O. Pure standalone `@mcp.tool` / `@mcp.resource` / `@mcp.prompt` functions may be sync; keep blocking I/O out of the event loop.
 
 ## Quick Reference
 
@@ -71,6 +71,7 @@ The default MCP surface is:
 | `base_path` | `str` | `"/mcp"` | URL prefix for the MCP Streamable HTTP endpoint |
 | `include_in_schema` | `bool` | `False` | Include MCP routes in OpenAPI |
 | `name` | `str \| None` | `None` | Server name; defaults to OpenAPI title |
+| `instructions` | `str \| None` | `None` | Server instructions advertised to MCP clients |
 | `guards` | `list[Any] \| None` | `None` | Litestar guards applied to the MCP router |
 | `allowed_origins` | `list[str] \| None` | `None` | Restrict accepted `Origin` headers |
 | `include_operations` | `list[str] \| None` | `None` | Only expose matching operation names |
@@ -80,6 +81,8 @@ The default MCP surface is:
 | `auth` | `MCPAuthConfig \| None` | `None` | OAuth protected-resource metadata |
 | `tasks` | `bool \| MCPTaskConfig` | `False` | Enable experimental in-memory MCP task support |
 | `list_page_size` | `int` | `100` | Page size for `tools/list`, `resources/list`, `resources/templates/list`, `prompts/list` (clients page via opaque cursors) |
+| `before_tool_call` | `BeforeToolCallHook \| None` | `None` | Observe each `tools/call` before dispatch |
+| `after_tool_call` | `AfterToolCallHook \| None` | `None` | Observe each `tools/call` result, exception, and duration |
 | `opt_keys` | `MCPOptKeys` | `MCPOptKeys()` | Rename the `handler.opt` keys the plugin reads (e.g. to avoid collisions) |
 | `session_store` | `Store \| None` | `None` | Litestar `Store` backing MCP sessions; defaults to an in-memory store |
 | `session_max_idle_seconds` | `float` | `3600.0` | Idle timeout before an MCP session is evicted |
@@ -145,6 +148,45 @@ Use structured metadata when the agent needs sharper tool selection:
 async def generate_report(data: ReportRequest) -> ReportQueued: ...
 ```
 
+### Standalone MCP App
+
+Use `MCP(...)` when the application is primarily an MCP server. Use `LitestarMCP(...)` when adding MCP to an existing Litestar app.
+
+```python
+from litestar_mcp import MCP
+
+
+mcp = MCP("inventory-mcp", instructions="Expose inventory tools.")
+
+
+@mcp.tool(name="lookup_product", description="Look up a product by SKU.")
+def lookup_product(sku: str) -> dict[str, str]:
+    return {"sku": sku, "status": "active"}
+
+
+@mcp.resource(uri="inventory://status", name="inventory_status")
+def inventory_status() -> dict[str, str]:
+    return {"status": "healthy"}
+
+
+@mcp.prompt(name="summarize_product")
+def summarize_product(sku: str) -> str:
+    return f"Summarize product {sku}."
+
+
+app = mcp.app
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")
+```
+
+`mcp.app` lazily builds the underlying `Litestar` instance; access it after registering standalone decorators. `@mcp.tool`, `@mcp.resource`, and `@mcp.prompt` accept normal Litestar route-handler kwargs such as `dependencies`, `guards`, `tags`, DTO options, hooks, and `sync_to_thread`. The `name` kwarg names the MCP primitive; use `route_name` when the Litestar route handler itself needs a name.
+
+`MCP(...)` also accepts `config=`, existing `plugins=`, existing `route_handlers=`, and standard `Litestar(...)` app kwargs. Use that pass-through when a standalone MCP app still needs Litestar middleware, dependencies, CORS, or additional non-MCP routes.
+
+`mcp.run(transport="sse", port=8000)` starts the HTTP/SSE transport through the Litestar CLI, so expose `app = mcp.app` at module scope or set `LITESTAR_APP` for worker/reload discovery. `mcp.run(transport="stdio")` reads line-delimited JSON-RPC from stdin, writes responses to stdout, manually drives ASGI lifespan, and dispatches through the same JSON-RPC router with a synthetic request context.
+
 ### Hiding Routes
 
 Discovery is opt-in: a handler that carries no `mcp_*` marker never appears in MCP. There is no per-route exclude flag — `opt={"mcp_exclude": True}` is ignored.
@@ -169,6 +211,24 @@ To drop *marked* routes in bulk, use the `MCPConfig` filters (`exclude_tags` / `
   }
 }
 ```
+
+Direct router use is transport-internal. Current `JSONRPCRouter.dispatch()` takes a parsed request plus `RequestContext`; HTTP builds that context from the live `Request`, while stdio uses `client_id="stdio"`, `owner_id="stdio"`, and `request=None`. Do not import `litestar_mcp.routes.build_jsonrpc_router`; use `LitestarMCP` or `MCP` unless you are maintaining `litestar-mcp` transport internals.
+
+### Pagination, Signatures, And Errors
+
+`tools/list`, `resources/list`, `resources/templates/list`, and `prompts/list` use opaque cursor pagination. Clients pass `params.cursor` from `nextCursor` until the response omits it; clients do not send `limit`. Set server page size with `MCPConfig(list_page_size=...)`; invalid cursors return `INVALID_PARAMS` (`-32602`).
+
+Tool arguments are validated against Litestar's `handler.parsed_fn_signature` before dispatch. Do not reference legacy `signature_model` or private validation-context parameter lists.
+
+Tool execution errors stay inside the tool result with `isError: true`; protocol errors such as unknown tool names use JSON-RPC errors. Resource and prompt handler failures use primitive-level JSON-RPC codes and preserve the handler HTTP status in `error.data.statusCode` when a handler response produced one. Do not invent status-code-specific JSON-RPC codes for 401/403/409/429.
+
+### Tool-Call Callbacks
+
+Use `MCPConfig.before_tool_call` and `MCPConfig.after_tool_call` for audit, metrics, or tracing that must fire around `tools/call` regardless of route ownership. Both callbacks receive the MCP tool name, a shallow copy of submitted arguments, and the synthesized `Request`. `after_tool_call` also receives keyword-only `result`, `exception`, and `duration`; it fires for successes, guard failures, handled error responses, and unhandled exceptions. Callback exceptions are logged and swallowed.
+
+### Dependency Providers And Dishka
+
+Litestar `Provide(...)` factory parameters that are user inputs, such as pagination or filter values, remain in tool schemas and forward during `tools/call`. When `dishka.integrations.litestar.setup_dishka()` is attached, provider-factory parameters whose annotated type is resolvable from `app.state.dishka_container` are treated as DI inputs instead of MCP arguments. Dishka remains optional; installs without Dishka should still import and run `litestar_mcp`.
 
 ### Built-in OpenAPI Resource
 
@@ -240,7 +300,7 @@ List only the routes that should be callable by AI clients. Mark those routes wi
 
 ### Step 3: Add the Plugin
 
-Wire `LitestarMCP(MCPConfig(name=...))` into `Litestar(plugins=[...])`. Use `include_tags` or `include_operations` when you need a second allowlist.
+Wire `LitestarMCP(MCPConfig(name=...))` into `Litestar(plugins=[...])`, or use standalone `MCP(...)` when the app exists only to serve MCP primitives. Use `include_tags` or `include_operations` when you need a second allowlist.
 
 ### Step 4: Add Auth
 
@@ -248,7 +308,7 @@ For public endpoints, configure bearer-token validation and `MCPAuthConfig` meta
 
 ### Step 5: Verify
 
-Hit `POST /mcp` with `tools/list` and `resources/list`. Confirm only marked routes appear. Call one representative tool and read one representative resource.
+For Streamable HTTP, initialize first: `POST /mcp` with `initialize`, send `notifications/initialized`, then include the returned `Mcp-Session-Id` header on later `tools/list`, `resources/list`, `tools/call`, and `resources/read` requests. Confirm only marked routes appear, call one representative tool, and read one representative resource. For standalone stdio apps, send one line-delimited JSON-RPC request through stdin and confirm the response is written to stdout.
 
 </workflow>
 
@@ -263,6 +323,8 @@ Hit `POST /mcp` with `tools/list` and `resources/list`. Confirm only marked rout
 - **Keep DTOs precise** - loose `dict[str, Any]` request schemas produce weak tool contracts.
 - **Use `MCPAuthConfig` plus token validation for public MCP** - metadata alone does not authenticate requests.
 - **Set `allowed_origins` for browser-accessible MCP clients** - leave it `None` only for trusted server-to-server deployments.
+- **Treat `MCP` and `LitestarMCP` as public entry points** - avoid private router/service imports unless you are maintaining `litestar-mcp` transport internals.
+- **Keep observability callbacks side-effect safe** - `before_tool_call` / `after_tool_call` failures are swallowed, so callbacks must not enforce authorization or business invariants.
 
 </guardrails>
 
@@ -272,15 +334,17 @@ Hit `POST /mcp` with `tools/list` and `resources/list`. Confirm only marked rout
 
 Before delivering an MCP integration, verify:
 
-- [ ] `LitestarMCP` is in `app.plugins`
-- [ ] Exposed routes use `mcp_tool=`, `mcp_resource=`, or `mcp_resource_template=`
+- [ ] Existing Litestar apps include `LitestarMCP` in `app.plugins`; standalone apps expose `app = mcp.app`
+- [ ] Exposed routes/functions use `mcp_tool=`, `mcp_resource=`, `mcp_prompt=`, `@mcp.tool`, `@mcp.resource`, or `@mcp.prompt`
 - [ ] Admin / internal routes are left unmarked, or kept outside `include_*` / inside `exclude_*` — with `guards` or auth enforcing access
 - [ ] Auth is configured for the deployment boundary
 - [ ] `POST /mcp` `tools/list` returns only intended tools
 - [ ] `POST /mcp` `resources/list` includes only intended resources plus `litestar://openapi`
 - [ ] Filtered tools/resources/templates fail direct invocation as unknown
-- [ ] Provider-declared query parameters appear in tool `inputSchema` and forward during `tools/call`
-- [ ] Exposed handlers are `async def` and return JSON-serializable types
+- [ ] Provider-declared user inputs appear in tool `inputSchema`; Dishka-resolved service parameters do not
+- [ ] `before_tool_call` / `after_tool_call` callbacks are covered when configured, including failure paths
+- [ ] Standalone `MCP` SSE or stdio transport is smoke-tested for the chosen deployment mode
+- [ ] Exposed handlers performing I/O are `async def`; sync standalone functions are pure/non-blocking and return JSON-serializable types
 - [ ] Tool argument DTOs are specific enough for generated schemas
 
 </validation>

--- a/plugins/litestar/skills/litestar-queues/SKILL.md
+++ b/plugins/litestar/skills/litestar-queues/SKILL.md
@@ -1,0 +1,476 @@
+---
+name: litestar-queues
+description: "Auto-activate for litestar_queues, QueuePlugin, QueueConfig, QueueService, @task, QueuedBackgroundTask, TaskResult, litestar queues run/status/scheduler-health, queue backends, execution backends, schedules, or task progress events. Not for litestar-saq/SAQ, Celery, RQ, or Dramatiq — those use different APIs and worker lifecycles."
+---
+
+# litestar-queues
+
+`litestar-queues` is the first-party Litestar worker abstraction for task registration, queue persistence, worker lifecycle, schedules, and application-facing queue events.
+
+Use it when a Litestar app needs its own queue layer with explicit queue backend selection, local or Cloud Run execution, `QueueService` DI, and task progress events. Keep queue storage and execution separate:
+
+- **Queue backend** stores task records and state.
+- **Execution backend** decides where claimed work runs.
+
+## Code Style Rules
+
+- Use PEP 604 unions: `T | None`, never `Optional[T]`.
+- Use `async def` for route handlers, dependency resolvers, task I/O, and event publishing.
+- Inject `QueueService` with `NamedDependency[QueueService]`; do not import a module-level queue service in handlers.
+- Import core APIs from `litestar_queues`. Import optional backend config classes from their documented backend submodules.
+- Keep task payloads JSON-serializable when using Redis, Valkey, SQLSpec, Advanced Alchemy, or Cloud Run backends.
+- Prefer `msgspec` for event/client DTOs in Litestar apps unless the project already standardizes on Pydantic.
+
+## Quick Reference
+
+### Minimal Plugin Setup
+
+```python
+from litestar import Litestar, post
+from litestar.di import NamedDependency
+from litestar_queues import QueueConfig, QueuePlugin, QueueService, task
+
+
+@task("accounts.sync", queue="accounts", retries=3, timeout=300)
+async def sync_account(account_id: str) -> dict[str, str]:
+    return {"account_id": account_id, "status": "synced"}
+
+
+@post("/accounts/{account_id:str}/sync")
+async def create_sync_job(
+    account_id: str,
+    queue_service: NamedDependency[QueueService],
+) -> dict[str, str]:
+    result = await queue_service.enqueue(sync_account, account_id)
+    return {"task_id": str(result.id), "status": result.status or "queued"}
+
+
+app = Litestar(
+    route_handlers=[create_sync_job],
+    plugins=[QueuePlugin(config=QueueConfig())],
+)
+```
+
+### Task Registration and Enqueueing
+
+```python
+from datetime import timedelta
+
+from litestar_queues import QueueService, task
+
+
+@task(
+    "reports.render",
+    queue="reports",
+    priority=10,
+    retries=2,
+    timeout=120,
+    run_after=30,
+)
+async def render_report(report_id: str) -> str:
+    return report_id
+
+
+async def queue_report(queue_service: QueueService, report_id: str) -> str:
+    result = await queue_service.enqueue(
+        render_report,
+        report_id,
+        key=f"report:{report_id}",
+        timeout=600,
+        metadata={"requested_by": "system"},
+    )
+    await result.wait(timeout=30)
+    return result.status or "unknown"
+
+
+@task("reports.refresh", interval=timedelta(minutes=15), jitter=30)
+async def refresh_reports() -> None:
+    ...
+
+
+@task("billing.close-day", cron="0 0 * * *", timezone="UTC")
+async def close_billing_day() -> None:
+    ...
+```
+
+`QueueService.enqueue()` accepts a decorated `Task` object or registered task name. Use `task_modules=("app.tasks",)` or `discover_tasks("app.domain")` so string-enqueued tasks and schedules are imported during startup.
+
+`TaskResult` is a handle over the queued record. Use `await result.refresh()` to reload state and `await result.wait(timeout=30)` to poll until `completed`, `failed`, or `cancelled`.
+
+### Background Responses
+
+```python
+from litestar import Response, post
+from litestar_queues import QueuedBackgroundTask, task
+
+
+@task("imports.process")
+async def process_import(path: str) -> None:
+    ...
+
+
+@post("/imports")
+async def create_import() -> Response[dict[str, str]]:
+    return Response(
+        {"status": "queued"},
+        background=QueuedBackgroundTask(process_import, "/tmp/data.csv"),
+    )
+```
+
+Use `QueuedBackgroundTask` when a response should be sent before enqueueing. It resolves the active `QueueService` from `QueuePlugin`; pass `service=queue_service` when using a custom service.
+
+### Worker Placement
+
+```python
+# Local development, tests, and lightweight deployments.
+queue_config = QueueConfig(in_app_worker=True)
+
+# Production sidecar/worker service.
+queue_config = QueueConfig(in_app_worker=False)
+```
+
+```bash
+LITESTAR_APP=app:app litestar queues run --drain-timeout 30
+LITESTAR_APP=app:app litestar queues run --queue accounts --max-concurrency 4
+LITESTAR_APP=app:app litestar queues status --json
+LITESTAR_APP=app:app litestar queues scheduler-health --minutes 5
+```
+
+In-app workers share the web process and are the default. Standalone workers load the same Litestar app, open the plugin service, and process all queues unless `--queue` is repeated.
+
+### Backend and Execution Selection
+
+| Need | Queue backend | Execution backend | Install / import |
+| --- | --- | --- | --- |
+| Unit tests, examples, one-process local apps | `queue_backend="memory"` | `"local"` or `"immediate"` | Core package |
+| SQLSpec-first app or SQL-backed persistence without SQLAlchemy ORM | `SQLSpecBackendConfig(...)` | `"local"` | `litestar-queues[sqlspec]`; `from litestar_queues.backends.sqlspec import SQLSpecBackendConfig` |
+| Advanced Alchemy / SQLAlchemy app with Alembic-owned models | `AdvancedAlchemyBackendConfig(...)` | `"local"` | `litestar-queues[advanced-alchemy]`; `from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyBackendConfig` |
+| Redis already in the stack for cache, pub/sub, or shared infra | `RedisBackendConfig(...)` | `"local"` | `litestar-queues[redis]`; `from litestar_queues.backends.redis import RedisBackendConfig` |
+| Valkey is the chosen Redis-compatible service | `ValkeyBackendConfig(...)` | `"local"` | `litestar-queues[valkey]`; `from litestar_queues.backends.valkey import ValkeyBackendConfig` |
+| Inline test/script execution with completed results immediately | Any backend | `"immediate"` | Core package |
+| Heavy or isolated jobs on Google Cloud Run Jobs | Persistent queue backend | `CloudRunExecutionConfig(...)` | `litestar-queues[cloudrun]`; `from litestar_queues.execution.cloudrun import CloudRunExecutionConfig` |
+
+Pick the backend that matches the project:
+
+- Use `memory` only for same-process work; it does not coordinate separate worker processes.
+- Use `SQLSpecBackendConfig` when the app already uses SQLSpec or wants adapter-level SQL persistence.
+- Use `AdvancedAlchemyBackendConfig` when the app already uses Advanced Alchemy / SQLAlchemy models and migrations; import the queue model into Alembic when the app owns schema.
+- Use `RedisBackendConfig` or `ValkeyBackendConfig` when that service already exists and task payloads can stay JSON-serializable.
+- Use `CloudRunExecutionConfig` only for execution; keep queue persistence on memory only for local experiments and on a shared persistent backend for real deployments.
+
+### SQLSpec Queue Backend
+
+```python
+from sqlspec.adapters.aiosqlite import AiosqliteConfig
+
+from litestar_queues import QueueConfig
+from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
+
+
+queue_config = QueueConfig(
+    queue_backend=SQLSpecBackendConfig(
+        config=AiosqliteConfig(connection_config={"database": "queue.db"}),
+        create_schema=False,
+        run_migrations=True,
+    ),
+    execution_backend="local",
+    in_app_worker=False,
+)
+```
+
+### Advanced Alchemy Queue Backend
+
+```python
+from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig
+from litestar_queues import QueueConfig
+from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyBackendConfig
+
+
+alchemy_config = SQLAlchemyAsyncConfig(connection_string="sqlite+aiosqlite:///queue.db")
+
+queue_config = QueueConfig(
+    queue_backend=AdvancedAlchemyBackendConfig(
+        sqlalchemy_config=alchemy_config,
+        create_schema=False,
+    ),
+    execution_backend="local",
+)
+```
+
+Set `create_schema=True` only for local bootstrap or tests. Production apps that manage schema with Alembic should import the queue model into the Alembic environment. Use `QueueTaskModelMixin` plus `model_class=` when the app needs its own table name, base class, bind metadata, or migration ownership.
+
+### Redis or Valkey Queue Backend
+
+```python
+from litestar_queues import QueueConfig
+from litestar_queues.backends.redis import RedisBackendConfig
+
+
+queue_config = QueueConfig(
+    queue_backend=RedisBackendConfig(
+        url="redis://localhost:6379/0",
+        key_prefix="litestar_queues",
+        notifications=True,
+    ),
+    execution_backend="local",
+)
+```
+
+Swap `RedisBackendConfig` for `ValkeyBackendConfig` from `litestar_queues.backends.valkey` when the project uses Valkey.
+
+### Cloud Run Execution
+
+```python
+from litestar_queues import QueueConfig, task
+from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
+from litestar_queues.execution.cloudrun import CloudRunExecutionConfig
+
+
+@task("reports.render", execution_backend="cloudrun", execution_profile="heavy")
+async def render_report(report_id: str) -> None:
+    ...
+
+
+queue_config = QueueConfig(
+    queue_backend=SQLSpecBackendConfig(config=...),
+    execution_backend=CloudRunExecutionConfig(
+        project_id="example-project",
+        region="us-central1",
+        job_name="queue-worker",
+        profiles={"heavy": "queue-worker-heavy"},
+        extra_env={
+            "LITESTAR_QUEUES_CONFIG_FACTORY": "app.queue:create_queue_config",
+            "LITESTAR_QUEUES_TASK_MODULES": "app.tasks",
+        },
+    ),
+)
+```
+
+Run the Cloud Run container with `litestar-queues-cloudrun-worker` or `python -m litestar_queues.execution.cloudrun.entrypoint`. The entrypoint reads `LITESTAR_QUEUES_TASK_ID`, loads `LITESTAR_QUEUES_CONFIG_FACTORY` and `LITESTAR_QUEUES_TASK_MODULES`, claims the persisted record, heartbeats, executes, and returns deterministic exit codes. The config factory must return the same `QueueConfig`, `QueueService`, or async context manager used by the dispatch worker; otherwise the entrypoint falls back to an isolated default `QueueConfig()`.
+
+### Events and Progress
+
+```python
+from litestar_queues import QueueConfig, task
+from litestar_queues.events import QueueEventConfig, publish_task_log, publish_task_progress
+
+
+queue_config = QueueConfig(
+    event_config=QueueEventConfig(
+        enabled=True,
+        channels_backend=channels,
+        publish_global_lifecycle=True,
+    ),
+)
+
+
+@task("imports.process")
+async def process_import(path: str) -> None:
+    await publish_task_log("Import started", payload={"path": path})
+    await publish_task_progress(current=5, total=10, message="Halfway done")
+```
+
+Queue events are application-facing envelopes. They are separate from queue backend wakeup notifications. Use `TaskExecutionContext` via `_task_context` when a task needs direct access to `progress()`, `log()`, or `event()`.
+
+### Dependency Resolver
+
+```python
+from typing import Any
+
+from litestar_queues import QueueConfig, QueuedTaskRecord, Task, TaskExecutionContext, task
+
+
+async def resolve_task_dependencies(
+    _task: Task[Any, Any],
+    _record: QueuedTaskRecord,
+    _context: TaskExecutionContext,
+) -> dict[str, Any]:
+    return {"settings": {"environment": "production"}}
+
+
+@task("reports.generate")
+async def generate_report(*, settings: dict[str, Any]) -> str:
+    return f"generated for {settings['environment']}"
+
+
+queue_config = QueueConfig(task_dependency_resolver=resolve_task_dependencies)
+```
+
+Resolvers run once per attempt after `task.started` and before the task body. Return kwargs that match task parameters. Resolver exceptions follow the normal retry/failure path.
+
+<workflow>
+
+## Workflow
+
+### Step 1: Identify the Work Shape
+
+Use `litestar-queues` when the app needs durable task state, scheduled jobs, progress events, or worker placement choices. Use `QueuedBackgroundTask` only when the Litestar response lifecycle is the trigger and the actual work should still go through the queue.
+
+### Step 2: Pick Queue Backend
+
+Match the project stack. Start with `memory` only for tests and local single-process apps. Use SQLSpec for SQLSpec apps, Advanced Alchemy for SQLAlchemy/Advanced Alchemy apps, Redis for Redis-backed infrastructure, and Valkey for Valkey infrastructure.
+
+### Step 3: Pick Execution Backend
+
+Use `local` for normal in-process worker execution. Use `immediate` for tests and scripts that need inline completion. Use `CloudRunExecutionConfig` when tasks must run in Google Cloud Run Jobs and the queue backend is shared across web, dispatch worker, and remote worker containers.
+
+### Step 4: Configure `QueuePlugin`
+
+Register `QueuePlugin(config=QueueConfig(...))` in `Litestar(plugins=[...])`. Set `task_modules` when tasks are not otherwise imported before startup. Keep `initialize_schedules=True` unless schedule sync is owned by a separate process.
+
+### Step 5: Define Tasks and Schedules
+
+Decorate callables with `@task("name", ...)`. Put defaults on the decorator (`queue`, `priority`, `retries`, `timeout`, `run_after`, `execution_backend`, `execution_profile`, `key`). Use `interval` or five-field `cron`, not both.
+
+### Step 6: Enqueue from Handlers or Services
+
+Inject `QueueService` with `NamedDependency[QueueService]`. Call `await queue_service.enqueue(task_or_name, *args, **kwargs)` and use `TaskResult.refresh()` or `TaskResult.wait()` only when the caller truly needs observed completion.
+
+### Step 7: Place Workers
+
+Keep `in_app_worker=True` for tests, local development, and lightweight apps. Set `in_app_worker=False` and run `litestar queues run` as a separate service when web and background capacity must scale independently.
+
+### Step 8: Add Events and Resolver Hooks
+
+Enable `QueueEventConfig` only when clients or operators consume lifecycle, progress, log, or custom events. Add `task_dependency_resolver` only when tasks need services from an external DI container.
+
+</workflow>
+
+<guardrails>
+
+## Guardrails
+
+- **Use `QueuePlugin` for Litestar apps** — it wires DI, app state, lifespan, task module imports, schedule initialization, worker startup, and CLI commands.
+- **Do not use `memory` for standalone production workers** — memory state is process-local and cannot coordinate web and worker processes.
+- **Do not mix queue backend and execution backend concerns** — Cloud Run is execution; Redis, Valkey, SQLSpec, Advanced Alchemy, and memory store queue state.
+- **Do not import optional backends from `litestar_queues.backends`** — import config classes from `litestar_queues.backends.sqlspec`, `.advanced_alchemy`, `.redis`, or `.valkey`.
+- **Set `task_modules` or call `discover_tasks()`** when enqueueing by string or relying on schedules; decorators register tasks only after modules import.
+- **Use `QueueService.enqueue()` in handlers and services** — reserve `Task.enqueue()` for code running under an active `QueuePlugin` default service or for intentional immediate fallback.
+- **Always set explicit `timeout` on real tasks** — long-running workers need predictable cancellation and failure behavior.
+- **Use `key=` for deduplication** when repeated requests target the same logical job.
+- **Treat backend wakeup notifications as hints** — workers still rely on polling and durable queue state.
+- **Keep dependency resolvers per-attempt clean** — return fresh request/session handles and let failures participate in normal task retry handling.
+- **Use `scheduler-health` only after registering a recurring canary task** matching `QueueConfig.scheduler_canary_task`.
+
+</guardrails>
+
+<validation>
+
+### Validation Checkpoint
+
+Before delivering Litestar Queues code, verify:
+
+- [ ] `QueuePlugin(config=QueueConfig(...))` is registered in `app.plugins`
+- [ ] `QueueConfig.queue_backend` matches the project's persistence stack
+- [ ] `QueueConfig.execution_backend` matches where tasks should run
+- [ ] `in_app_worker` is intentional for the deployment shape
+- [ ] Standalone deployments use a shared persistent queue backend
+- [ ] `task_modules` or `discover_tasks()` imports all decorated task modules
+- [ ] Handlers inject `NamedDependency[QueueService]`
+- [ ] Enqueue calls use `QueueService.enqueue()` with explicit `timeout`, `retries`, and `key` where needed
+- [ ] Scheduled tasks use either `interval` or five-field `cron`
+- [ ] `initialize_schedules` is enabled in exactly one startup path when multiple app processes exist
+- [ ] Event publishing is enabled only when a sink or Channels backend is configured
+- [ ] Dependency resolver output matches task keyword parameters
+- [ ] `litestar queues run/status/scheduler-health` commands load the intended Litestar app through `LITESTAR_APP` or `--app`
+
+</validation>
+
+<example>
+
+## Example
+
+**Task:** A Litestar app queues report jobs to SQLSpec, runs workers as a standalone service, publishes progress, and has a scheduler canary.
+
+```python
+from datetime import timedelta
+
+from litestar import Litestar, post
+from litestar.di import NamedDependency
+from sqlspec.adapters.aiosqlite import AiosqliteConfig
+
+from litestar_queues import QueueConfig, QueuePlugin, QueueService, task
+from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
+from litestar_queues.events import publish_task_log, publish_task_progress
+
+
+@task("reports.render", queue="reports", retries=2, timeout=300)
+async def render_report(report_id: str) -> dict[str, str]:
+    await publish_task_log("Report rendering started", payload={"report_id": report_id})
+    await publish_task_progress(current=1, total=2, message="Rendering")
+    return {"report_id": report_id, "status": "rendered"}
+
+
+@task("scheduler.heartbeat", interval=timedelta(minutes=1), timeout=10)
+async def scheduler_heartbeat() -> None:
+    return None
+
+
+@post("/reports/{report_id:str}/render")
+async def enqueue_report(
+    report_id: str,
+    queue_service: NamedDependency[QueueService],
+) -> dict[str, str]:
+    result = await queue_service.enqueue(
+        render_report,
+        report_id,
+        key=f"report:{report_id}",
+        description="Render report",
+    )
+    return {"task_id": str(result.id), "status": result.status or "queued"}
+
+
+queue_config = QueueConfig(
+    queue_backend=SQLSpecBackendConfig(
+        config=AiosqliteConfig(connection_config={"database": "queue.db"}),
+        create_schema=False,
+        run_migrations=True,
+    ),
+    execution_backend="local",
+    in_app_worker=False,
+    worker_max_concurrency=4,
+)
+
+app = Litestar(
+    route_handlers=[enqueue_report],
+    plugins=[QueuePlugin(config=queue_config)],
+)
+```
+
+```bash
+LITESTAR_APP=app:app litestar queues run --queue reports --max-concurrency 4 --drain-timeout 60
+LITESTAR_APP=app:app litestar queues status --json
+LITESTAR_APP=app:app litestar queues scheduler-health --minutes 5
+```
+
+</example>
+
+## References Index
+
+- **[litestar](../litestar/SKILL.md)** — Litestar app setup, plugin lists, DI, and lifespan.
+- **[litestar-routing](../litestar-routing/SKILL.md)** — Controller and route handler patterns for enqueue endpoints.
+- **[litestar-realtime](../litestar-realtime/SKILL.md)** — Channels and WebSocket delivery for queue progress streams.
+- **[sqlspec](../sqlspec/SKILL.md)** — SQLSpec adapter and extension configuration.
+- **[advanced-alchemy](../advanced-alchemy/SKILL.md)** — Advanced Alchemy SQLAlchemy config, repositories, and Alembic ownership.
+
+## Official References
+
+- <https://github.com/cofin/litestar-queues/releases/tag/v0.1.0>
+- <https://github.com/cofin/litestar-queues>
+- <https://cofin.github.io/litestar-queues/>
+- <https://cofin.github.io/litestar-queues/usage/configuration.html>
+- <https://cofin.github.io/litestar-queues/usage/backends.html>
+- <https://cofin.github.io/litestar-queues/usage/tasks.html>
+- <https://cofin.github.io/litestar-queues/usage/workers.html>
+- <https://cofin.github.io/litestar-queues/usage/events.html>
+- <https://cofin.github.io/litestar-queues/usage/schedules.html>
+- <https://cofin.github.io/litestar-queues/usage/cli.html>
+- <https://cofin.github.io/litestar-queues/usage/dependency-resolver.html>
+
+## Shared Styleguide Baseline
+
+- Use shared styleguides for generic language/framework rules to reduce duplication in this skill.
+- [General Principles](../litestar-styleguide/references/general.md)
+- [Python](../litestar-styleguide/references/python.md)
+- [Litestar](../litestar-styleguide/references/litestar.md)
+- Keep this skill focused on `litestar-queues` workflows, backend selection, worker placement, and task/event APIs.

--- a/plugins/litestar/skills/litestar-vite/SKILL.md
+++ b/plugins/litestar/skills/litestar-vite/SKILL.md
@@ -11,6 +11,8 @@ The reference apps use `spa`, `template`, `htmx`, `hybrid` / `inertia`, `framewo
 
 The plugin pairs with the npm package [`litestar-vite-plugin`](https://www.npmjs.com/package/litestar-vite-plugin) on the JS side. Python `ViteConfig` is the source of truth; the generated `.litestar.json` bridge lets JS config normally keep only `litestar({ input: [...] })`.
 
+Current release note: `litestar-vite` `0.24.0` through `0.25.0` tightened SPA route exclusion, Inertia bootstrap/partial-reload behavior, Litestar 3 deprecation prep, and Vite 8.1 HMR config shape. See [Release Updates](references/release-updates.md).
+
 ## Code Style Rules
 
 - **Python**: PEP 604 unions (`T | None`); consumer Litestar app modules MAY use `from __future__ import annotations`.
@@ -273,7 +275,24 @@ Common HMR gotchas:
 - **Hot file mismatch**: remove JS `hotFile` overrides or align them with `ViteConfig.paths.hot_file`. Mismatch ⇒ stale prod URLs in dev.
 - **CORS errors**: use default proxy mode first. In direct/two-port mode, set `server.cors: true` so the Litestar origin can fetch dev assets.
 - **Port conflict**: proxy mode can auto-pick a Vite port. In direct/two-port mode, pin `runtime.port` and `server.port`.
+- **Vite 8.1 HMR deprecation**: put HMR network fields under `server.ws`, not `server.hmr`. Keep `server.hmr=false` only when disabling HMR. Use `server.hmr` network fields only when the project is pinned to Vite 7 or 8.0.
 - **Browsers cache `manifest.json`**: cache-bust by hash; never serve manifest.json from a CDN with long TTL.
+
+Vite 8.1+ explicit HMR network override:
+
+```ts
+export default defineConfig({
+  server: {
+    ws: {
+      host: "localhost",
+      path: "vite-hmr",
+      clientPort: 8000,
+    },
+  },
+})
+```
+
+Prefer no explicit HMR network override in proxy mode. Let `litestar-vite-plugin` write the version-correct config from the `.litestar.json` bridge.
 
 ### Production Build & Deploy
 
@@ -322,6 +341,13 @@ vite = VitePlugin(
 
 app = Litestar(plugins=[vite], middleware=[session_backend.middleware])
 ```
+
+Current Inertia behavior:
+
+- Initial non-Inertia visits return an HTML bootstrap. Inertia visits (`X-Inertia: true`) return JSON.
+- Handler returns shaped like prop bags (`dict`, `msgspec.Struct`, dataclass instance, or Pydantic model) become top-level page props. They are not nested under `content`.
+- Deferred props remain advertised on initial responses. A partial reload that resolves a deferred key strips that key from `deferredProps`; unrequested deferred keys stay advertised.
+- Use `litestar-vite-plugin` as the bridge owner. Do not add `@inertiajs/vite` to generated Litestar scaffolds by default.
 
 See `../litestar-inertia/SKILL.md` for client adapter setup.
 
@@ -381,6 +407,7 @@ For HTMX, register `HTMXPlugin()` and keep `ViteConfig(mode="htmx", ...)`.
 
 - **`ViteConfig` is the source of truth** — avoid JS-side `bundleDir`, `hotFile`, and `assetUrl` overrides unless this is a standalone/mono-repo override. Mismatch breaks HMR or manifest resolution silently.
 - **Use proxy mode by default** — Vite can auto-pick a port and the hot file carries the actual URL. Pin `server.port` only for direct/two-port workflows.
+- **Use `server.ws` for Vite 8.1+ HMR network overrides** — `server.hmr.host`, `server.hmr.port`, `server.hmr.clientPort`, `server.hmr.path`, `server.hmr.protocol`, and `server.hmr.timeout` are the Vite 7 / 8.0 shape.
 - **Set `server.cors: true` only for different public origins** — proxy mode keeps Litestar as the public origin.
 - **Toggle `dev_mode` from env**, never hardcode `True` in committed code — leaving dev mode on in prod proxies to a non-existent dev server.
 - **Keep `RuntimeConfig.start_dev_server=True` in dev** so `litestar run` starts/stops Vite. For prod, set `dev_mode=False`.
@@ -404,6 +431,7 @@ Before delivering a `litestar-vite` integration, verify:
 - [ ] JS-side `bundleDir` / `hotFile` / `assetUrl` overrides are absent or intentionally match `ViteConfig`
 - [ ] `dev_mode` is env-toggled
 - [ ] Direct/two-port workflows pin `server.port`; proxy-mode workflows do not rely on a fixed Vite port
+- [ ] Vite 8.1+ HMR network overrides use `server.ws`; Vite 7 / 8.0 overrides use `server.hmr`
 - [ ] `server.cors: true` only if Litestar and Vite are different public origins in dev
 - [ ] Template base file uses `vite_hmr()` before `vite(...)`
 - [ ] If `types=TypeGenConfig(...)`, generated types are committed or CI verifies they are up-to-date
@@ -504,6 +532,7 @@ For deep-dives on specific surfaces, see:
 - **[HMR](references/hmr.md)** — HMR architecture, debugging, common pitfalls.
 - **[Deployment](references/deployment.md)** — Production build, static hosting, CDN patterns, cache strategy.
 - **[Troubleshooting](references/troubleshooting.md)** — Common errors and fixes.
+- **[Release Updates](references/release-updates.md)** — `litestar-vite` `0.24.0` through `0.25.0` behavior changes.
 
 ## Cross-References
 

--- a/plugins/litestar/skills/litestar-vite/references/config.md
+++ b/plugins/litestar/skills/litestar-vite/references/config.md
@@ -83,6 +83,8 @@ Also configure Vite top-level:
 | `base` | Asset URL base; CDN URL in prod |
 | `publicDir` | Static files copied verbatim |
 | `server.port` | Optional in proxy mode; pin for direct/external two-port workflows |
+| `server.ws` | Vite 8.1+ HMR network overrides (`host`, `port`, `clientPort`, `path`, `protocol`, `timeout`) |
+| `server.hmr` | Vite 7 / 8.0 HMR network overrides; `false` disables HMR |
 | `server.cors: true` | Only needed when Litestar and Vite are different public origins |
 | `build.outDir` | Match `bundle_dir` |
 | `build.emptyOutDir` | `true` to avoid stale assets |

--- a/plugins/litestar/skills/litestar-vite/references/hmr.md
+++ b/plugins/litestar/skills/litestar-vite/references/hmr.md
@@ -27,6 +27,32 @@ In dev mode:
 
 React projects get Fast Refresh through the Vite React plugin and HMR client. Keep `vite_hmr()` before the entrypoint tag.
 
+## Vite 8.1+ HMR Config Shape
+
+Vite 8.1 moved HMR network options from `server.hmr.*` to `server.ws.*`.
+
+Use this shape only when you must override the network settings explicitly:
+
+```ts
+export default defineConfig({
+  server: {
+    ws: {
+      host: "localhost",
+      path: "vite-hmr",
+      clientPort: 8000,
+      protocol: "ws",
+    },
+  },
+})
+```
+
+Rules:
+
+- Vite 8.1+: place `host`, `port`, `clientPort`, `path`, `protocol`, and `timeout` under `server.ws`.
+- Vite 7 / 8.0: place those fields under `server.hmr`.
+- Disabling HMR remains `server.hmr = false`.
+- In proxy mode, omit explicit HMR network settings unless the default bridge-derived values are wrong.
+
 ## Common Issues
 
 ### Stale prod URLs in dev
@@ -52,6 +78,12 @@ Fix: first use the default proxy mode so Litestar is the public origin. In direc
 Symptom: HMR works some runs, fails others. Asset URLs point at unexpected ports.
 
 Fix: in proxy mode, let Vite auto-pick and read the generated hot-file URL. In direct/two-port mode, pin both `RuntimeConfig.port` (Python) and `server.port` (JS) to the same value.
+
+### Vite 8.1 HMR deprecation warning
+
+Symptom: Vite logs that `server.hmr.*` network options are deprecated.
+
+Fix: move HMR network options to `server.ws` when running Vite 8.1+. If the project must support Vite 7 or 8.0 from the same `vite.config.ts`, avoid explicit HMR network config and let `litestar-vite-plugin` emit the version-gated shape.
 
 ### HMR works but full reloads happen
 
@@ -86,5 +118,6 @@ Fix: never set long TTL on `manifest.json`. Hash the bundles (Vite default), but
 - [ ] `hot_file` exists at the configured path during a dev session
 - [ ] Browser network tab shows JS fetched through Litestar's proxy in default mode, or from the pinned Vite origin in direct mode
 - [ ] `vite_hmr()` rendered to a `<script>` tag in the served HTML
+- [ ] Vite 8.1+ configs use `server.ws` for HMR network fields
 - [ ] Browser console shows `[vite] connected`
 - [ ] WebSocket frames appear in network tab on file edit

--- a/plugins/litestar/skills/litestar-vite/references/modes.md
+++ b/plugins/litestar/skills/litestar-vite/references/modes.md
@@ -251,6 +251,8 @@ See [`../../litestar-htmx/SKILL.md`](../../litestar-htmx/SKILL.md) for the full 
 - Page components live in `resources/js/pages/<component>/<name>.tsx`
 - Configure one `VitePlugin` with `ViteConfig(inertia=InertiaConfig(...))`
 - Page-prop type generation via `TypeGenConfig` + Inertia's schema
+- `dict`, `msgspec.Struct`, dataclass, and Pydantic handler returns are prop bags: initial visits bootstrap HTML, and Inertia visits spread fields as top-level props
+- Deferred props advertise metadata on initial responses; partial reloads strip only the keys they just resolved from `deferredProps`
 
 ```python
 from litestar import Controller, Litestar, get

--- a/plugins/litestar/skills/litestar-vite/references/release-updates.md
+++ b/plugins/litestar/skills/litestar-vite/references/release-updates.md
@@ -1,0 +1,54 @@
+# litestar-vite - Release Updates 0.24.0 to 0.25.0
+
+Use this file when refreshing guidance against current upstream `litestar-vite` releases.
+
+## Release Anchors
+
+| Version | Upstream change | Skill guidance |
+| --- | --- | --- |
+| `0.24.0` | SPA handler excludes its own routes from Litestar route-prefix detection. | Non-root `spa_path` values such as `/ui` remain reachable while real backend routes still win. If `/ui/...` fails with `Not an SPA route`, upgrade before adding local workarounds. |
+| `0.24.0` | Deferred Inertia props strip resolved keys from `deferredProps` on partial reload. | Initial responses still advertise deferred metadata. Partial reload responses remove only keys they resolved; unrequested deferred props remain advertised. |
+| `0.24.0` | Litestar 3 deprecation prep and Inertia integration cleanup. | Use `litestar.plugins.jinja.JinjaTemplateEngine` in examples. Keep `litestar-vite-plugin` as the Litestar bridge owner; do not add `@inertiajs/vite` to generated scaffolds by default. |
+| `0.24.1` | Structured Inertia handler returns bootstrap as HTML props. | `dict`, `msgspec.Struct`, dataclass, and Pydantic model returns are prop bags. Initial visits return HTML; Inertia visits spread fields as top-level props. |
+| `0.25.0` | Vite 8.1 HMR `server.ws.*` deprecation fix. | Vite 8.1+ HMR network fields belong under `server.ws`; Vite 7 / 8.0 use `server.hmr`; `server.hmr=false` still disables HMR. |
+
+## Vite 8.1 HMR Shape
+
+Prefer no explicit HMR network override in proxy mode. Let `litestar-vite-plugin` emit the version-gated shape from the `.litestar.json` bridge.
+
+When an override is required on Vite 8.1+:
+
+```ts
+export default defineConfig({
+  server: {
+    ws: {
+      host: "localhost",
+      path: "vite-hmr",
+      clientPort: 8000,
+    },
+  },
+})
+```
+
+Do not place `host`, `port`, `clientPort`, `path`, `protocol`, or `timeout` under `server.hmr` on Vite 8.1+. Use that legacy shape only for Vite 7 or 8.0.
+
+## Inertia Behavior
+
+- Treat `dict`, `msgspec.Struct`, dataclass, and Pydantic model handler returns as shallow prop bags.
+- Initial non-Inertia visits return HTML bootstrap responses.
+- Inertia visits (`X-Inertia: true`) return JSON with fields as top-level props.
+- Deferred props are advertised on initial responses.
+- A partial reload that resolves a deferred prop removes that key from `deferredProps`; it does not remove unrelated deferred keys.
+- Keep `litestar-vite-plugin` responsible for the bridge, dev/prod asset resolution, proxy routing, type generation, CSRF helper wiring, and `resolvePageComponent()`.
+
+## Upstream Sources
+
+- `v0.24.0` release: <https://github.com/litestar-org/litestar-vite/releases/tag/v0.24.0>
+- `v0.24.1` release: <https://github.com/litestar-org/litestar-vite/releases/tag/v0.24.1>
+- `v0.25.0` release: <https://github.com/litestar-org/litestar-vite/releases/tag/v0.25.0>
+- SPA route exclusion: <https://github.com/litestar-org/litestar-vite/pull/264>
+- Deferred props partial reload fix: <https://github.com/litestar-org/litestar-vite/pull/265>
+- Litestar 3 and Inertia integration prep: <https://github.com/litestar-org/litestar-vite/pull/269>
+- Structured Inertia bootstrap returns: <https://github.com/litestar-org/litestar-vite/pull/277>
+- Vite 8.1 HMR shape: <https://github.com/litestar-org/litestar-vite/pull/293>
+- Vite server options: <https://vite.dev/config/server-options>

--- a/plugins/litestar/skills/litestar-vite/references/troubleshooting.md
+++ b/plugins/litestar/skills/litestar-vite/references/troubleshooting.md
@@ -18,6 +18,7 @@ See `hmr.md` for the full debug checklist. Quick summary:
 - Vite not actually running (check `litestar run` logs)
 - CORS / port mismatch in direct mode
 - Missing `vite_hmr()` in template
+- Vite 8.1+ config still puts HMR network fields under `server.hmr` instead of `server.ws`
 
 ## Type Generation Fails
 
@@ -44,6 +45,15 @@ See `hmr.md` for the full debug checklist. Quick summary:
 | Page renders as JSON, not HTML | `ViteConfig.inertia` missing or route lacks `component=` / Inertia response helper | Add `InertiaConfig(...)` to `ViteConfig`; set `mode="hybrid"` when explicit mode is needed |
 | Type errors on page props | `inertia-pages.json` / `page-props.ts` stale | Re-run `litestar assets generate-types` |
 | First-load works, navigations break | `root_template` missing Inertia head tags | Use Inertia layout pattern in `base.html` |
+| Structured handler return nests under `content` or boots as JSON | Running pre-0.24.1 behavior or bypassing the Inertia wrapper | Upgrade to `litestar-vite>=0.24.1`; return a prop bag from a `component=` handler |
+| Deferred props loop after partial reload | Resolved keys are echoed back in `deferredProps` | Upgrade to `litestar-vite>=0.24.0`; resolved partial-reload keys are stripped from metadata |
+
+## SPA Catch-All Issues
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Non-root `spa_path` such as `/ui` returns `Not an SPA route` | SPA handler's own route is treated as a non-SPA Litestar route in pre-0.24.0 versions | Upgrade to `litestar-vite>=0.24.0`; keep real API routes registered normally |
+| API routes return SPA HTML | Catch-all SPA route is too broad or registered before explicit routes | Register explicit API routes and let SPA fallback serve only non-Litestar paths |
 
 ## Performance
 

--- a/plugins/litestar/skills/sqlspec/SKILL.md
+++ b/plugins/litestar/skills/sqlspec/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: sqlspec
-description: "Auto-activate for sqlspec, SQLSpec, SQLFileLoader, drivers, query builders, named SQL, filters, pagination, Arrow, framework extensions, ADK stores, data dictionary, or observers. Not for ORM repositories."
+description: "Auto-activate for sqlspec, SQLSpec, SQLFileLoader, drivers, query builders, named SQL, filters, pagination, Arrow, framework extensions, ADK stores, data dictionary, or observers. Not for ORM repositories -- use advanced-alchemy."
 ---
 
 # SQLSpec Skill
 
-SQLSpec is a **type-safe SQL query mapper for Python** -- NOT an ORM. It provides flexible connectivity with consistent interfaces across 18+ database adapters. Write raw SQL, use the builder API, or load SQL from files. All statements pass through a sqlglot-powered AST pipeline for validation and dialect conversion.
+SQLSpec is a **type-safe SQL query mapper for Python** -- NOT an ORM. It provides flexible connectivity with consistent interfaces across 18+ database adapters. Write raw SQL, use the builder API, or load SQL from files. Statements pass through a sqlglot-powered AST pipeline for validation, parameter handling, and dialect conversion.
 
 ## Match-Your-Framework — read first
 
@@ -46,9 +46,9 @@ db_manager.add_config(config)
 
 # Use SQLSpec's session provider for connection lifecycle
 async with db_manager.provide_session(config) as db:
-    users = await db.select_many(
+    users = await db.select(
         "SELECT * FROM users WHERE active = $1",
-        [True],
+        True,
         schema_type=User,
     )
 ```
@@ -91,24 +91,37 @@ stmt = (
 
 | Method | Returns | Use Case |
 | --- | --- | --- |
+| `select()` / `fetch()` | List of rows | Filtered queries, listing |
 | `select_value()` | Single scalar | `COUNT(*)`, `MAX()`, existence checks |
+| `select_value_or_none()` | Scalar or `None` | Optional scalar lookup |
 | `select_one()` | One row (strict) | Get-by-ID, raises `NotFoundError` |
 | `select_one_or_none()` | One row or `None` | Optional lookup |
-| `select_many()` | List of rows | Filtered queries, listing |
-| `select_to_arrow()` | `pyarrow.Table` | Bulk data export, analytics |
-| `execute()` | Row count | INSERT/UPDATE/DELETE |
-| `execute_many()` | Row count | Batch operations |
+| `select_with_total()` | Rows plus total | Pagination |
+| `select_stream()` / `fetch_stream()` | Context-managed row stream | Bounded row iteration where adapter supports native streaming |
+| `select_to_arrow()` / `fetch_to_arrow()` | `ArrowResult` | Bulk data export, analytics |
+| `execute()` | `SQLResult` | INSERT/UPDATE/DELETE metadata |
+| `execute_many()` | `SQLResult` | Batch operation metadata |
+| `load_from_arrow()` | `StorageBridgeJob` | Native Arrow bulk ingest |
+| `load_from_storage()` | `StorageBridgeJob` | Load staged files or cloud URIs |
+| `load_from_records()` | `StorageBridgeJob` | Native bulk ingest for in-memory records |
 
 ### Arrow Integration Basics
 
 ```python
-# Zero-copy on DuckDB, ADBC adapters; conversion on others
-arrow_table = await db.select_to_arrow(
-    "SELECT * FROM large_dataset WHERE region = $1", [region]
+# Native Arrow on ADBC, DuckDB, BigQuery, Spanner, mssql-python, arrow-odbc,
+# and oracledb; conversion path on other adapters unless native_only=True.
+arrow_result = await db.select_to_arrow(
+    "SELECT * FROM large_dataset WHERE region = $1",
+    region,
+    return_format="reader",
+    batch_size=10_000,
 )
 
 # Bulk load from Arrow
-await db.copy_from_arrow(arrow_table, target_table="users")
+await db.load_from_arrow("users", arrow_result)
+
+# Bulk load records through the same native ingest path
+await db.load_from_records("users", [{"id": 1, "name": "Ada"}])
 ```
 
 <workflow>
@@ -122,13 +135,14 @@ await db.copy_from_arrow(arrow_table, target_table="users")
 | PostgreSQL async | `asyncpg`, `psycopg` | Async, NUMERIC/PYFORMAT params |
 | PostgreSQL sync | `psycopg` | Sync+async, PYFORMAT params |
 | SQLite | `sqlite`, `aiosqlite` | QMARK params, local dev |
-| DuckDB analytics | `duckdb` | Arrow-native, zero-copy |
+| DuckDB analytics | `duckdb` | Arrow-native OLAP, extension load/install lifecycle |
 | MySQL async | `asyncmy` | PYFORMAT params |
 | Oracle | `oracledb` | NAMED_COLON params, sync+async |
-| BigQuery / Spanner | `bigquery`, `spanner` | NAMED_AT params |
-| Raw SQL strings | Driver methods | `select_many()`, `execute()` |
+| BigQuery / Spanner | `bigquery`, `spanner` | NAMED_AT params, cloud job/session controls |
+| Raw SQL strings | Driver methods | `select()`, `execute()` |
 | Dynamic queries | Query builder | `sql.select()...to_statement()` |
-| SQL from files | `SQLFileLoader` | Metadata directives, caching |
+| SQL from files | `SQLFileLoader` | Metadata directives, `-- param:` declarations, caching |
+| High-volume ingest | Storage bridge | `load_from_arrow()`, `load_from_storage()`, `load_from_records()` |
 
 ### Step 2: Implement
 
@@ -137,6 +151,8 @@ await db.copy_from_arrow(arrow_table, target_table="users")
 3. Choose the appropriate driver method for your query shape
 4. Use `schema_type` parameter for typed results (Pydantic or msgspec models)
 5. Apply filters with `LimitOffsetFilter`, `OrderByFilter`, `SearchFilter`
+6. Use `select_stream(..., native_only=True)` when bounded-memory streaming is mandatory
+7. Use `load_from_records()` or `load_from_arrow()` for high-volume ingest; avoid row-by-row `execute_many()` for bulk pipelines
 
 ### Step 3: Validate
 
@@ -153,9 +169,13 @@ Run through the validation checkpoint below before considering the work complete
 - **Always use context managers** for driver lifecycle -- `async with db_manager.provide_session(config) as db:`
 - **Prefer the query builder** for complex dynamic queries -- avoids string concatenation, handles dialect conversion
 - **Prefer `SQLFileLoader`** for static queries -- keeps SQL out of Python, enables caching
+- **Use `-- param:` declarations for named SQL files that cross service boundaries** -- load-time and execute-time validation catches name drift and required parameter omissions
+- **Use `native_only=True` for streaming or Arrow paths only when fallback is unacceptable** -- unsupported adapters otherwise use eager row conversion
+- **Pass regular query bind values as positional arguments** -- `await db.select("... WHERE id = $1", user_id, schema_type=User)`, not `await db.select(..., [user_id], ...)`
 - **Never concatenate SQL strings** -- use parameterized queries or the query builder
 - **Never hold connections outside context managers** -- connection leaks exhaust the pool
 - **Match parameter style to adapter**: `$1` for asyncpg, `%s` for psycopg, `?` for sqlite, `:name` for oracledb
+- **Do not invent adapter APIs** -- BigQuery job controls live in `driver_features`; Spanner request controls live in `driver_features` or `provide_session()` kwargs
 - **Adapter config / driver modules avoid `from __future__ import annotations`**. Consumer app modules MAY use it.
 
 </guardrails>
@@ -172,6 +192,9 @@ Before delivering SQLSpec code, verify:
 - [ ] Query results use `schema_type` for type-safe mapping
 - [ ] Complex dynamic queries use the builder API, not string concatenation
 - [ ] Filters use SQLSpec filter objects (`LimitOffsetFilter`, etc.) not manual LIMIT/OFFSET
+- [ ] Streaming code uses context managers and sets `native_only=True` when eager fallback would be a bug
+- [ ] Bulk ingest code uses `load_from_arrow()`, `load_from_storage()`, or `load_from_records()` and checks adapter gates such as MySQL local-infile, Oracle direct path load, BigQuery Storage Write API, or Spanner Batch Write API
+- [ ] ADK stores are selected from supported adapter `adk` packages; BigQuery is not an ADK backend
 
 </validation>
 
@@ -220,9 +243,9 @@ async def list_active_users(page: int = 1, page_size: int = 25) -> list[User]:
     ]
 
     async with db_manager.provide_session(config) as db:
-        users = await db.select_many(
+        users = await db.select(
             "SELECT id, name, email, active FROM users WHERE active = $1",
-            [True],
+            True,
             *filters,
             schema_type=User,
         )
@@ -232,80 +255,16 @@ async def list_active_users(page: int = 1, page_size: int = 25) -> list[User]:
 async def get_user_count() -> int:
     async with db_manager.provide_session(config) as db:
         count = await db.select_value(
-            "SELECT COUNT(*) FROM users WHERE active = $1", [True]
+            "SELECT COUNT(*) FROM users WHERE active = $1", True
         )
         return count
 ```
 
 </example>
 
-## Query Builder
-
-The `sql` factory provides a fluent builder API with full method chaining. All builders terminate with `.to_statement()` and pass through sqlglot for validation and dialect conversion.
-
-| Builder | Entry Point | Key Methods |
-| --- | --- | --- |
-| SELECT | `sql.select(*cols)` | `.from_()`, `.where()`, `.where_eq()`, `.join()`, `.order_by()`, `.limit()`, `.offset()` |
-| INSERT | `sql.insert(table)` | `.columns()`, `.values()`, `.returning()` |
-| UPDATE | `sql.update(table)` | `.set_()`, `.where()`, `.returning()` |
-| DELETE | `sql.delete(table)` | `.where()`, `.returning()` |
-| MERGE | `sql.merge_(target)` | `.using()`, `.when_matched()`, `.when_not_matched()` |
-| CREATE TABLE | `sql.create_table(name)` | `.column()`, `.primary_key()`, `.if_not_exists()` |
-| DROP TABLE | `sql.drop_table(name)` | `.if_exists()`, `.cascade()` |
-
-## ArrowResult
-
-`select_to_arrow()` returns an Apache Arrow `Table` for bulk and analytical workloads:
-
-- **Zero-copy** on DuckDB and ADBC-native adapters — no serialization overhead
-- **Conversion path** on other adapters — rows are materialized into an Arrow schema
-- Returned tables are compatible with Polars, Pandas, and PyArrow directly
-- Use `copy_from_arrow(table, target_table)` for bulk loads back into the database
-
-## Filters
-
-SQLSpec filter objects are passed directly to driver methods alongside the SQL string. They modify the statement before execution.
-
-| Filter | Purpose | Example Use |
-| --- | --- | --- |
-| `BeforeAfterFilter` | Date range bounds (`before`, `after`) | Audit log queries, time-range pagination |
-| `InCollectionFilter` | SQL `IN (...)` clause | Filter by a set of IDs or enum values |
-| `LimitOffsetFilter` | Page-based pagination | `limit=25, offset=50` |
-| `OrderByFilter` | Dynamic sort columns and direction | User-supplied sort fields |
-| `SearchFilter` | Text search (`ILIKE` / `LIKE`) | Full-text style search on string columns |
-
-Filters are composable — pass multiple to a single `select_many()` call and they are applied in order.
-
-## Framework Integrations
-
-| Framework | Integration | Key Feature |
-| --- | --- | --- |
-| Litestar | `SQLSpecPlugin` | Dependency injection of typed driver; auto session lifecycle |
-| FastAPI / Starlette | Middleware | Request-scoped connection; injects driver into route dependencies |
-| Flask | Extension | `init_app()` pattern; driver available via `g` or `current_app` |
-
-`SQLSpecPlugin` for Litestar registers the driver as a DI provider — inject it into route handlers via type annotation without manual context management.
-
-## Event Channels
-
-For databases that support server-side pub/sub (e.g., PostgreSQL `LISTEN`/`NOTIFY`):
-
-- Use `AsyncEventChannel` to subscribe to named channels
-- Publish with `NOTIFY channel, payload` from SQL or from the `publish()` method
-- Handlers receive `EventMessage` objects with channel name, payload, and PID
-- Useful for real-time cache invalidation, cross-process coordination, and background job triggers
-
-## Key Design Principles
-
-1. **Single Source of Truth**: The `SQL` object holds all state for a given statement
-2. **Immutability**: All operations on a `SQL` object return new instances
-3. **Type Safety**: Parameters carry type information through the processing pipeline
-4. **Protocol-Based Design**: Uses Python protocols for runtime type checking instead of inheritance
-5. **Single-Pass Processing**: Parse once, transform once, validate once
-
 ## References Index
 
-> **Choosing between `sqlspec` and `advanced-alchemy`:** `advanced-alchemy` gives you an opinionated ORM service layer with `UUIDAuditBase`, lifecycle hooks, repository / service / Alembic integration, and `OffsetPagination[T]` out of the box — pick it when you want a complete CRUD surface with attribute-style row access and you're happy inside the SQLAlchemy ecosystem. `sqlspec` gives you direct SQL control, 18+ driver adapters (asyncpg, oracledb, DuckDB, BigQuery, SQLite, and more), Arrow-native result streams for analytics, and a builder API when you need it — pick it when you want explicit SQL, heterogeneous database backends, or Arrow integration. Both skills integrate with Litestar via first-party plugins; see [`../advanced-alchemy/SKILL.md`](../advanced-alchemy/SKILL.md) for the ORM path.
+> **Choosing between `sqlspec` and `advanced-alchemy`:** `advanced-alchemy` gives you an opinionated ORM service layer with `UUIDAuditBase`, lifecycle hooks, repository / service / Alembic integration, and `OffsetPagination[T]` out of the box — pick it when you want a complete CRUD surface with attribute-style row access and you're happy inside the SQLAlchemy ecosystem. `sqlspec` gives you direct SQL control, 18+ driver adapters (asyncpg, oracledb, DuckDB, BigQuery, SQLite, and more), Arrow result paths for analytics, and a builder API when you need it — pick it when you want explicit SQL, heterogeneous database backends, or Arrow integration. Both skills integrate with Litestar via first-party plugins; see [`../advanced-alchemy/SKILL.md`](../advanced-alchemy/SKILL.md) for the ORM path.
 
 For detailed instructions, patterns, and API guides, refer to the following documents:
 
@@ -319,18 +278,20 @@ For detailed instructions, patterns, and API guides, refer to the following docu
 
 ### Architecture & Performance
 
-- **[Architecture & Caching](references/architecture.md)** -- Core data flow, NamespacedCache system, Mypyc compilation.
-- **[Data Dictionary](references/data-dictionary.md)** -- Dialect feature flags, runtime introspection (`get_tables`, `get_columns`, `get_indexes`), driver-side metadata API.
+- **[Architecture & Caching](references/architecture.md)** -- Core data flow, NamespacedCache system, statement/cache tuning, Mypyc compilation.
+- **[Performance & Cloud Controls](references/performance.md)** -- Bounded async bridge, cache/fetch tuning, BigQuery job controls, Spanner session controls.
+- **[Data Dictionary](references/data-dictionary.md)** -- Dialect feature flags, runtime introspection (`get_tables`, `get_columns`, `get_indexes`), ADBC native metadata/statistics.
 
 ### Query Building & Execution
 
 - **[Query Builder API](references/query_builder.md)** -- `sql` factory: select, insert, update, delete, merge.
-- **[Driver Method Reference](references/driver_api.md)** -- `select_value()`, `select_one()`, `select_many()`, `select_to_arrow()`.
+- **[Driver Method Reference](references/driver_api.md)** -- `select()`, `select_one()`, `select_stream()`, `select_to_arrow()`, load methods.
 - **[Filter & Pagination System](references/filters.md)** -- `LimitOffsetFilter`, `OrderByFilter`, `SearchFilter`.
 
 ### Data Integration
 
-- **[Arrow & ADBC Integration](references/arrow.md)** -- `select_to_arrow()` zero-copy, `copy_from_arrow()` bulk loading.
+- **[Arrow & ADBC Integration](references/arrow.md)** -- `select_to_arrow()` formats, Arrow-native paths, conversion fallbacks.
+- **[Native Bulk Ingest](references/bulk-ingest.md)** -- `load_from_arrow()`, `load_from_storage()`, `load_from_records()`, adapter gates.
 - **[SQL File Loading](references/loader.md)** -- `SQLFileLoader` with search paths, metadata directives.
 
 ### Adapters & Drivers
@@ -342,7 +303,7 @@ For detailed instructions, patterns, and API guides, refer to the following docu
 - **[Framework Extensions](references/extensions.md)** -- Litestar plugin, FastAPI/Starlette integration.
 - **[Storage Integration](references/storage.md)** -- ADK store, Litestar session stores, event channel backends.
 - **[Event Channels (Pub/Sub)](references/events.md)** -- `AsyncEventChannel`, subscribe/publish patterns.
-- **[ADK Extension](references/adk.md)** -- `SQLSpecSessionService`, `SQLSpecMemoryService`, `SQLSpecArtifactService`, per-adapter ADK stores.
+- **[ADK Extension](references/adk.md)** -- ADK 2 session/memory stores, scoped state, artifact service contracts.
 
 ### Migrations & Schema
 

--- a/plugins/litestar/skills/sqlspec/references/adapters.md
+++ b/plugins/litestar/skills/sqlspec/references/adapters.md
@@ -10,23 +10,37 @@
 | Arrow ODBC | `"arrow_odbc"` | dynamic | QMARK (`?`) | `helper` | No | Arrow-native |
 | AsyncMy | `"asyncmy"` | `mysql` | PYFORMAT (`%s`) | `helper` | Yes | MySQL native |
 | AsyncPG | `"asyncpg"` | `postgres` | NUMERIC (`$1`) | `driver` | Yes | asyncpg codecs |
-| BigQuery | `"bigquery"` | `bigquery` | NAMED_AT (`@name`) | `helper` | Yes | BQ type mapping |
+| BigQuery | `"bigquery"` | `bigquery` | NAMED_AT (`@name`) | `helper` | No | BQ type mapping |
 | CockroachDB Asyncpg | `"cockroach_asyncpg"` | `postgres` | NUMERIC (`$1`) | `driver` | Yes | asyncpg codecs |
 | CockroachDB Psycopg | `"cockroach_psycopg"` | `postgres` | PYFORMAT (`%s`) | `helper` | Yes | psycopg adapt |
 | DuckDB | `"duckdb"` | `duckdb` | QMARK (`?`) | `helper` | No | Arrow-native |
 | MSSQL Python | `"mssql_python"` | `tsql` | QMARK (`?`) | `helper` | Both | SQL Server native |
-| MysqlConnector | `"mysql_connector"` | `mysql` | PYFORMAT (`%s`) | `helper` | No | MySQL native |
+| MysqlConnector | `"mysqlconnector"` | `mysql` | PYFORMAT (`%s`) | `helper` | Both | MySQL native |
 | OracleDB | `"oracledb"` | `oracle` | NAMED_COLON (`:name`) | `helper` | Both | Oracle DB API |
 | PSQLPy | `"psqlpy"` | `postgres` | NUMERIC (`$1`) | `helper` | Yes | Rust-backed |
 | Psycopg | `"psycopg"` | `postgres` | PYFORMAT (`%s`) | `helper` | Both | psycopg adapt |
 | PyMySQL | `"pymysql"` | `mysql` | PYFORMAT (`%s`) | `helper` | No | MySQL native |
-| Spanner | `"spanner"` | `spanner` | NAMED_AT (`@name`) | `helper` | Yes | Spanner proto |
+| Spanner | `"spanner"` | `spanner` | NAMED_AT (`@name`) | `helper` | No | Spanner proto |
 | SQLite | `"sqlite"` | `sqlite` | QMARK (`?`) | `helper` | No | Python stdlib |
 
 ### JSON Strategy
 
 - **`driver`**: The database driver handles JSON serialization natively (AsyncPG, CockroachDB Asyncpg). Zero overhead.
 - **`helper`**: SQLSpec serializes JSON values before binding. Works universally.
+
+---
+
+## Capability Snapshot
+
+Check the adapter config flags before building generic tooling:
+
+| Capability | Native adapters | Caveats |
+| --- | --- | --- |
+| Row streaming with `select_stream()` / `fetch_stream()` | `asyncpg`, `cockroach_asyncpg`, `psycopg`, `cockroach_psycopg`, `psqlpy`, `pymysql`, `aiomysql`, `asyncmy`, `mysqlconnector`, `sqlite`, `aiosqlite`, `oracledb`, `bigquery` | `adbc`, `duckdb`, `mssql_python`, `arrow_odbc`, and `spanner` use eager fallback only. Use `native_only=True` when fallback would violate memory bounds. |
+| Arrow export with native `select_to_arrow()` override | `adbc`, `arrow_odbc`, `duckdb`, `bigquery`, `spanner`, `mssql_python`, `oracledb` | Other adapters use the base dict-to-Arrow conversion for `select_to_arrow()`; `native_only=True` raises there. `config.supports_arrow_streaming` is a streaming capability flag, not a separate API. |
+| Native ingest through `load_from_arrow()` / `load_from_records()` | PostgreSQL family, MySQL family, SQLite family, `adbc`, `duckdb`, `oracledb`, `bigquery`, `spanner`, `mssql_python`, `arrow_odbc` | `load_from_records()` normalizes to Arrow first. MySQL local-infile, Oracle direct path load, BigQuery Storage Write API, and Spanner Batch Write API have explicit gates. |
+| ADK session/event and memory stores | `asyncpg`, `psycopg`, `psqlpy`, `cockroach_asyncpg`, `cockroach_psycopg`, `aiomysql`, `asyncmy`, `mysqlconnector`, `pymysql`, `aiosqlite`, `sqlite`, `oracledb`, `duckdb`, `adbc`, `spanner` | BigQuery and `mssql_python` are not ADK backends. Artifact service contracts exist, but concrete adapter artifact metadata stores are deployment-provided. |
+| Cloud job/session controls | `bigquery`, `spanner` | BigQuery controls live in `BigQueryConfig.driver_features`; Spanner controls live in `SpannerSyncConfig.driver_features`, per-call kwargs, and `provide_session()` / `provide_read_session()`. |
 
 ---
 
@@ -90,7 +104,7 @@ Each adapter's `core.py` module exports these helpers:
 
 ### PostgreSQL
 
-- **asyncpg**: Best throughput, native JSON/UUID, zero-copy Arrow. Use for high-performance async apps.
+- **asyncpg**: Best throughput, native JSON/UUID, and PostgreSQL COPY ingest. Use for high-performance async apps.
 - **psycopg**: Broadest compatibility, sync + async, PgBouncer-friendly. Use when you need sync or connection pooling.
 - **psqlpy**: Rust-backed async driver. Use when you want Rust performance with Python ergonomics.
 - **cockroach_asyncpg / cockroach_psycopg**: CockroachDB-specific. Built-in retry logic for serialization conflicts (`40001`), follower reads.
@@ -99,7 +113,7 @@ Each adapter's `core.py` module exports these helpers:
 
 - **asyncmy**: Async MySQL with good performance. Use for async applications.
 - **pymysql**: Pure Python sync driver. Use for simple scripts or when C extensions are unavailable.
-- **mysql_connector**: Oracle's official connector. Use when vendor support matters.
+- **mysqlconnector**: Oracle's official connector. Use when vendor support matters.
 
 ### SQLite
 
@@ -167,8 +181,9 @@ class MyDriver(SyncDriverAdapterBase):
 
 ### DuckDB
 
-- Native Apache Arrow support with zero-copy for `select_to_arrow()` and `copy_from_arrow()`.
+- Native Apache Arrow support for `select_to_arrow()` and `load_from_arrow()`.
 - Best for in-memory analytics and local OLAP workloads.
+- `DuckDBExtensionConfig` separates install and load lifecycle: `install=True` forces an `install_extension()` call, `force_install=True` reinstalls, and `required=True` turns load/install failures from best-effort warnings into exceptions.
 
 ### BigQuery
 

--- a/plugins/litestar/skills/sqlspec/references/adk.md
+++ b/plugins/litestar/skills/sqlspec/references/adk.md
@@ -1,12 +1,12 @@
 # SQLSpec ADK Extension
 
-`sqlspec.extensions.adk` is the SQL-backed storage layer for Google's **Agent Development Kit (ADK)** session, memory, and artifact abstractions. ADK defines abstract services (`BaseSessionService`, `BaseMemoryService`, `BaseArtifactService`); SQLSpec ships concrete SQL-backed implementations that plug into any adapter.
+`sqlspec.extensions.adk` is the SQL-backed storage layer for Google's **Agent Development Kit (ADK)** session, event, and memory abstractions. ADK defines abstract services (`BaseSessionService`, `BaseMemoryService`, `BaseArtifactService`); SQLSpec ships session/event and memory implementations for supported adapters plus artifact service contracts for deployments that provide a concrete artifact metadata store.
 
 ## What ADK Is
 
-Google's ADK is a Python framework for building LLM agents (`LlmAgent`, `Runner`, tool calls, structured events). ADK is storage-agnostic — you point it at a session service, memory service, and (optionally) an artifact service, and it persists state across turns. SQLSpec's `extensions.adk` module provides those three services backed by a real database rather than in-memory dicts.
+Google's ADK is a Python framework for building LLM agents (`LlmAgent`, `Runner`, tool calls, structured events). ADK is storage-agnostic — you point it at a session service, memory service, and (optionally) an artifact service, and it persists state across turns. SQLSpec's `extensions.adk` module provides database-backed session and memory services, plus an artifact service when paired with a concrete artifact metadata store.
 
-## The Three Stores
+## Store Surface
 
 All store classes live under `sqlspec.extensions.adk`. Each has an async base (used by async adapters) and a sync base (used by sync adapters):
 
@@ -14,13 +14,13 @@ All store classes live under `sqlspec.extensions.adk`. Each has an async base (u
 | --- | --- | --- | --- |
 | `BaseAsyncADKStore` / `BaseSyncADKStore` | Conversation sessions + full event history | `SQLSpecSessionService` | `SessionRecord`, `EventRecord` |
 | `BaseAsyncADKMemoryStore` / `BaseSyncADKMemoryStore` | Long-term memory entries searchable per user | `SQLSpecMemoryService`, `SQLSpecSyncMemoryService` | `MemoryRecord` |
-| `BaseAsyncADKArtifactStore` / `BaseSyncADKArtifactStore` | Versioned artifact **metadata** (content lives in object storage) | `SQLSpecArtifactService` | `ArtifactRecord` |
+| `BaseAsyncADKArtifactStore` / `BaseSyncADKArtifactStore` | Versioned artifact **metadata** contract (content lives in object storage) | `SQLSpecArtifactService` | `ArtifactRecord` |
 
-All records are `TypedDict`s (see `sqlspec/extensions/adk/_types.py`, `memory/_types.py`, `artifact/_types.py`) so mypyc can compile the service layer without pulling in Pydantic at runtime.
+All records are `TypedDict`s (see `sqlspec/extensions/adk/_types.py`, `memory/_types.py`, `artifact/_types.py`) so mypyc can compile the service layer without pulling in Pydantic at runtime. Adapter support guarantees cover session/event and memory stores. Adapter-specific concrete artifact metadata stores are not part of the support matrix.
 
 ### Session store
 
-Stores one row per session plus N rows per event. The full ADK `Event` is dumped via `Event.model_dump_json(exclude_none=True)` into a single JSON column (`event_json`); a small number of indexed scalars (`session_id`, `invocation_id`, `author`, `timestamp`) are extracted for query performance. Reconstruction uses `Event.model_validate_json()`.
+Stores one row per session plus N rows per event. The full ADK `Event` is dumped via `event.model_dump(exclude_none=True, mode="json")` into a single JSON column (`event_data`); indexed scalars (`app_name`, `user_id`, `session_id`, `invocation_id`, `timestamp`) support filtering. Reconstruction uses `Event.model_validate()`.
 
 ### Memory store
 
@@ -28,14 +28,14 @@ Holds searchable memory entries extracted from completed sessions. The `SQLSpecM
 
 ### Artifact store
 
-Persists artifact **metadata** (filename, version, MIME type, `canonical_uri`, `custom_metadata`). The bytes live in a `sqlspec.storage` backend — `SQLSpecArtifactService` is constructed with `artifact_storage_uri="s3://..."` (or any URI the registry can resolve), and uses that for content reads/writes. Versioning is append-only starting from `0`.
+Persists artifact **metadata** when a deployment supplies a concrete metadata store. The metadata record tracks filename, version, MIME type, `canonical_uri`, and `custom_metadata`; bytes live in a `sqlspec.storage` backend via `artifact_storage_uri="s3://..."` or a registered storage alias. Versioning is append-only starting from `0`.
 
 ## Converters
 
 `sqlspec.extensions.adk.converters` bridges ADK's Pydantic models (`Session`, `Event`) and the `TypedDict` database records:
 
 - `session_to_record(session)` / `record_to_session(record, events)`
-- `event_to_record(event)` / `record_to_event(record)`
+- `event_to_record(event, app_name, user_id, session_id)` / `record_to_event(record)`
 - `filter_temp_state(state)` — strips `temp:`-prefixed keys so they never persist
 - `split_scoped_state(state)` / `merge_scoped_state(...)` — normalise the `app:`, `user:`, `temp:` prefixes ADK uses to scope state
 - `compute_update_marker(update_time)` — produces the same revision marker string ADK's built-in `StorageSession.get_update_marker()` emits, enabling optimistic-concurrency detection on `append_event`
@@ -44,7 +44,7 @@ Memory and artifact modules ship their own converter helpers (`sqlspec.extension
 
 ## Per-Adapter Store Implementations
 
-Production adapters ship concrete ADK stores from their `sqlspec.adapters.<adapter>.adk` package: `asyncpg`, `psycopg`, `psqlpy`, `cockroach_asyncpg`, `cockroach_psycopg`, `oracledb`, `sqlite`, `aiosqlite`, `duckdb`, `aiomysql`, `asyncmy`, `pymysql`, `mysqlconnector`, `spanner`, and `adbc`. Each contains both `<Adapter>ADKStore` (session/event) and `<Adapter>ADKMemoryStore` (memory).
+Production adapters ship concrete session/event and memory stores from their `sqlspec.adapters.<adapter>.adk` package: `asyncpg`, `psycopg`, `psqlpy`, `cockroach_asyncpg`, `cockroach_psycopg`, `oracledb`, `sqlite`, `aiosqlite`, `duckdb`, `aiomysql`, `asyncmy`, `pymysql`, `mysqlconnector`, `spanner`, and `adbc`. Each contains both `<Adapter>ADKStore` (session/event) and `<Adapter>ADKMemoryStore` (memory).
 
 Representative storage strategies:
 
@@ -58,17 +58,24 @@ Representative storage strategies:
 | `sqlite` / `aiosqlite` | `TEXT` with JSON1 functions | Local dev; small footprint |
 | `asyncmy` / `pymysql` / `mysqlconnector` | `JSON` | Uses MySQL's native JSON type |
 
-BigQuery and the `mock` adapter do **not** ship an ADK store; point those workloads at one of the adapters above.
+BigQuery and the `mock` adapter do **not** ship an ADK store. BigQuery was removed from the ADK backend surface because the batch-oriented job model does not fit ADK's low-latency transactional session/event writes. Use Spanner for a Google-managed operational backend or an OLTP backend such as PostgreSQL, MySQL, Oracle, SQLite, or CockroachDB.
 
 ## Schema Expectations
 
-Each store owns its DDL. The shipped migration under `sqlspec/extensions/litestar/migrations/0001_create_session_table.py` delegates to the adapter's store class for the `CREATE TABLE` — call `store._get_create_table_sql()` (or `ensure_tables()`) when bootstrapping outside of migrations. Table names are configurable via `extension_config["adk"]`:
+Each store owns its DDL. Call `ensure_tables()` or `create_tables()` when bootstrapping directly, or use SQLSpec migrations for managed deployments. Table names are configurable via `extension_config["adk"]`:
 
-- `session_table` (default `"adk_sessions"`)
-- `events_table` (default `"adk_events"`)
-- `memory_table` (default `"adk_memory_entries"`)
-- `artifact_table` (default `"adk_artifact_versions"`)
-- `owner_id_column` — optional DDL fragment (e.g. `"tenant_id INTEGER REFERENCES tenants(id)"`) for multi-tenant foreign keys
+- `session_table` (default `"adk_session"`)
+- `events_table` (default `"adk_event"`)
+- `app_state_table` (default `"adk_app_state"`)
+- `user_state_table` (default `"adk_user_state"`)
+- `metadata_table` (default `"adk_internal_metadata"`)
+- `memory_table` (default `"adk_memory"`)
+- `artifact_table` (default `"adk_artifact"`)
+- `owner_id_column` — optional DDL fragment (e.g. `"tenant_id INTEGER REFERENCES tenants(id)"`) for owner scoping when the store call path supplies owner IDs
+
+Migrations check that the selected adapter has the session and memory store classes before generating schema.
+
+The ADK 2 migration `0002_reset_adk_tables` is destructive: it drops legacy ADK session, event, state, metadata, and memory tables before recreating the 2.0 schema. Back up ADK data before applying it to an existing deployment.
 
 ## Litestar Handler Pattern
 
@@ -89,9 +96,9 @@ config = OracleAsyncConfig(
     connection_config={"dsn": "oracle+oracledb://app:app@oracle:1521/FREEPDB1"},
     extension_config={
         "adk": {
-            "session_table": "adk_sessions",
-            "events_table": "adk_events",
-            "memory_table": "adk_memory_entries",
+            "session_table": "adk_session",
+            "events_table": "adk_event",
+            "memory_table": "adk_memory",
         }
     },
 )
@@ -128,8 +135,8 @@ config = AsyncpgConfig(
     connection_config={"dsn": "postgresql://app:app@localhost/app"},
     extension_config={
         "adk": {
-            "session_table": "adk_sessions",
-            "events_table": "adk_events",
+            "session_table": "adk_session",
+            "events_table": "adk_event",
             "owner_id_column": "tenant_id INTEGER REFERENCES tenants(id)",
         }
     },
@@ -149,7 +156,7 @@ async def new_conversation(tenant_id: int, user_id: str) -> str:
     return session.id
 ```
 
-Synchronous adapters (`SqliteADKStore`, `DuckdbADKStore`, `OracleSyncADKStore`, etc.) use `SQLSpecSyncMemoryService` for the memory surface; session storage itself is async-only because the upstream ADK `BaseSessionService` interface is async.
+`SQLSpecSessionService` accepts async and sync stores. Sync store calls are bridged through SQLSpec's bounded async bridge because ADK's `BaseSessionService` interface is async. Memory has both `SQLSpecMemoryService` and `SQLSpecSyncMemoryService` surfaces.
 
 ## Public API Summary
 
@@ -161,6 +168,8 @@ Top-level exports from `sqlspec.extensions.adk`:
 - `BaseAsyncADKArtifactStore`, `BaseSyncADKArtifactStore`
 - `SessionRecord`, `EventRecord`, `MemoryRecord`, `ArtifactRecord`
 - `ADKConfig` (TypedDict describing `extension_config["adk"]`)
+
+`SQLSpecSessionService.append_event()` uses the store's `append_event_and_update_state()` as the durable write boundary. The event insert, session state update, and app/user scoped-state upserts succeed together. `temp:` state is stripped before persistence; `app:` and `user:` state live in separate tables and are merged back when sessions load.
 
 ## Cross References
 

--- a/plugins/litestar/skills/sqlspec/references/architecture.md
+++ b/plugins/litestar/skills/sqlspec/references/architecture.md
@@ -18,7 +18,7 @@ Raw SQL / Builder API / SQL File
     Driver Adapter (execute against database)
         |
         v
-    Result (rows, Arrow, scalar, rowcount)
+    Result (rows, Arrow, scalar, rows_affected)
 ```
 
 The `SQL` object is the single source of truth. All operations produce new `SQL` instances (immutability). The pipeline is single-pass: parse once, transform once, validate once.

--- a/plugins/litestar/skills/sqlspec/references/arrow.md
+++ b/plugins/litestar/skills/sqlspec/references/arrow.md
@@ -2,117 +2,117 @@
 
 ## Overview
 
-SQLSpec provides first-class Apache Arrow support for high-performance data transfer. Adapters that support ADBC or have native Arrow interfaces (DuckDB, BigQuery, Spanner) use zero-copy paths. All other adapters fall back to conversion from row dicts.
+SQLSpec exposes Arrow through `select_to_arrow()` / `fetch_to_arrow()` for export and the storage bridge methods for ingest. The export call returns `ArrowResult`, not a bare `pyarrow.Table`.
+
+Use Arrow for analytics, ETL, cross-database transfers, and native bulk ingest. Use row APIs for small request/response CRUD paths.
 
 ---
 
 ## select_to_arrow()
 
-Extract query results directly as a `pyarrow.Table`:
-
 ```python
-# Zero-copy on DuckDB, ADBC adapters
-arrow_table = await db_session.select_to_arrow(
+arrow_result = await db_session.select_to_arrow(
     "SELECT * FROM large_dataset WHERE region = $1",
-    [region],
+    region,
+    return_format="table",
+    native_only=False,
 )
 
-# arrow_table is a pyarrow.Table
-print(arrow_table.num_rows)
-print(arrow_table.schema)
+table = arrow_result.data
+print(arrow_result.rows_affected)
 ```
 
-### Performance Characteristics
+Supported `return_format` values:
 
-| Adapter | Path | Copy Overhead |
-| --- | --- | --- |
-| DuckDB | Native Arrow | Zero-copy |
-| ADBC | Native ADBC | Zero-copy |
-| BigQuery | Storage Read API | Zero-copy (streaming) |
-| Spanner | Native proto-Arrow | Near zero-copy |
-| AsyncPG | Conversion | Row-to-Arrow conversion |
-| Psycopg | Conversion | Row-to-Arrow conversion |
-| All others | Conversion | Row-to-Arrow conversion |
+| Value | Payload |
+| --- | --- |
+| `"table"` | Single `pyarrow.Table` |
+| `"batch"` | Single `pyarrow.RecordBatch` |
+| `"batches"` | Iterator of `RecordBatch` objects |
+| `"reader"` | `pyarrow.RecordBatchReader` |
+
+Use `batch_size=` for batch and reader shapes. Use `arrow_schema=` to cast or stabilize schema. Set `native_only=True` when conversion fallback would hide a performance or memory bug.
+
+### Native Export Paths
+
+| Adapter | Export behavior |
+| --- | --- |
+| `adbc` | ADBC native Arrow reader/table path |
+| `arrow_odbc` | ODBC Arrow batch reader path |
+| `duckdb` | DuckDB native Arrow result path |
+| `bigquery` | BigQuery native Arrow result path with configured job controls |
+| `spanner` | Spanner native Arrow conversion path |
+| `mssql_python` | SQL Server native Arrow/bulk-copy integration |
+| `oracledb` | Oracle Arrow export path |
+| Other adapters | Dict rows converted to Arrow unless `native_only=True` |
+
+`config.supports_arrow_streaming` advertises adapters with native streamed Arrow export behavior. It is a capability flag, not a separate public `select_arrow_stream()` method.
 
 ---
 
-## copy_from_arrow()
+## Row Streaming vs Arrow Results
 
-Bulk load data from an Arrow table into a database table:
+Use `select_stream()` for row-by-row processing. Use `select_to_arrow(return_format="reader")` for Arrow batch pipelines.
 
 ```python
-import pyarrow as pa
-
-# Create or obtain Arrow table
-arrow_table = pa.table({
-    "id": [1, 2, 3],
-    "name": ["Alice", "Bob", "Carol"],
-    "score": [95.5, 87.3, 92.1],
-})
-
-# Bulk load into database
-await db_session.copy_from_arrow(arrow_table, target_table="users")
+async with db_session.select_stream(
+    "SELECT id, payload FROM events ORDER BY id",
+    chunk_size=1_000,
+    native_only=True,
+) as stream:
+    async for row in stream:
+        await process_row(row)
 ```
 
-### Native Arrow Load Paths
-
-| Adapter | Method | Notes |
-| --- | --- | --- |
-| DuckDB | `INSERT INTO ... SELECT * FROM arrow_table` | In-process, zero-copy |
-| BigQuery | Load job with Arrow format | Streaming insert |
-| Spanner | Mutation-based insert | Batched |
-| ADBC | `adbc_ingest` | Native ADBC bulk load |
-
-For adapters without native Arrow support, SQLSpec converts the Arrow table to row-based parameters and uses `execute_many()`.
+Native row streaming and Arrow streaming are separate capabilities. An adapter can support one without the other.
 
 ---
 
-## record_batches() Iterator
+## Ingest From Arrow
 
-For streaming large result sets without loading everything into memory:
+Use `load_from_arrow()` for inbound Arrow data.
 
 ```python
-async for batch in db_session.record_batches(
-    "SELECT * FROM very_large_table",
-    batch_size=10_000,
-):
-    # batch is a pyarrow.RecordBatch
-    process_batch(batch)
+job = await target_session.load_from_arrow(
+    "refined_analytics",
+    arrow_result,
+    overwrite=False,
+)
+print(job.telemetry["rows_processed"])
 ```
+
+Native ingest routes through adapter-specific primitives: PostgreSQL `COPY`, DuckDB registration plus `INSERT ... SELECT`, ADBC `adbc_ingest`, Oracle direct path load when available, BigQuery load jobs or Storage Write API, Spanner mutations or Batch Write API, SQL Server `bulkcopy()`, `arrow_odbc` `bulk_insert_arrow`, SQLite transactional `executemany`, and MySQL `executemany` or gated `LOAD DATA LOCAL INFILE`.
+
+See [bulk-ingest.md](bulk-ingest.md) for adapter gates and caveats.
 
 ---
 
 ## Cross-Database Arrow Pipeline
 
-A common pattern is extracting data from one database and loading into another using Arrow as the interchange format:
-
 ```python
-# Extract from DuckDB (zero-copy)
-arrow_table = duckdb_session.select_to_arrow(
-    "SELECT * FROM local_analytics WHERE date > $1",
-    [cutoff_date],
+source_result = await source_session.select_to_arrow(
+    "SELECT * FROM events WHERE updated_at > $1",
+    last_sync,
+    return_format="table",
 )
 
-# Load into BigQuery (native Arrow load)
-await bq_session.copy_from_arrow(arrow_table, target_table="refined_analytics")
+job = await target_session.load_from_arrow("events", source_result)
 ```
 
-### Two-Path Strategy
+Guidance:
 
-1. **Native Arrow Path** (ADBC, DuckDB, BigQuery, Spanner):
-   - Zero-copy data transfer, 5-10x faster than row-based.
-   - Uses ADBC loaders and native driver Arrow support.
-2. **Conversion Path** (all other adapters):
-   - Dict results converted to Arrow via `pyarrow.Table.from_pylist()`.
-   - Arrow tables converted to row parameters via `.to_pylist()` for loading.
+- Keep `ArrowResult` intact when passing between SQLSpec sessions.
+- Use `return_format="reader"` for large exports that downstream code consumes in batches.
+- Use `native_only=True` in tests for critical native paths so a conversion fallback cannot pass unnoticed.
+- Use `load_from_records()` when data originates as Python records; it normalizes through Arrow and then uses the same ingest surface.
 
 ---
 
-## Arrow Type Mapping
+## Type Mapping
 
-SQLSpec maps database types to Arrow types automatically:
+SQLSpec maps database values to Arrow through adapter-native metadata when available, otherwise through Python dict-row conversion.
 
-| SQL Type | Arrow Type |
+| SQL Type | Typical Arrow Type |
 | --- | --- |
 | INTEGER / BIGINT | `int64` |
 | REAL / DOUBLE | `float64` |
@@ -122,5 +122,5 @@ SQLSpec maps database types to Arrow types automatically:
 | TIMESTAMP | `timestamp[us]` |
 | DECIMAL | `decimal128` |
 | BLOB / BYTEA | `binary` |
-| JSON / JSONB | `utf8` (serialized) |
-| UUID | `utf8` |
+| JSON / JSONB | serialized string or adapter-native JSON representation |
+| UUID | string unless adapter/native schema preserves UUID semantics |

--- a/plugins/litestar/skills/sqlspec/references/bulk-ingest.md
+++ b/plugins/litestar/skills/sqlspec/references/bulk-ingest.md
@@ -1,0 +1,77 @@
+# SQLSpec Native Bulk Ingest
+
+## Overview
+
+SQLSpec `v0.51.0` exposes native bulk ingest through three storage bridge methods:
+
+- `load_from_arrow(table, source, *, overwrite=False)` -- load an Arrow table or coercible Arrow source.
+- `load_from_storage(table, source, *, file_format, overwrite=False)` -- load a local path or cloud URI.
+- `load_from_records(table, records, *, columns=None, overwrite=False)` -- load in-memory rows.
+
+All three return `StorageBridgeJob`; inspect `job.telemetry["rows_processed"]`, `bytes_processed`, and adapter-specific `extra` metadata.
+
+---
+
+## load_from_records()
+
+Use `load_from_records()` for Python records. Mapping rows infer columns from keys; positional rows require `columns=`.
+
+```python
+await driver.load_from_records(
+    "orders",
+    [{"id": 1, "total": 9.99}, {"id": 2, "total": 4.50}],
+)
+
+await driver.load_from_records(
+    "orders",
+    [(3, 1.0), (4, 2.0)],
+    columns=["id", "total"],
+)
+```
+
+Records normalize to Arrow and route through the adapter's `load_from_arrow()` path. Empty input, mismatched mapping keys, and positional width mismatches raise `ImproperConfigurationError`.
+
+---
+
+## Adapter Matrix
+
+| Adapter | Native ingest path | Gate / caveat |
+| --- | --- | --- |
+| `asyncpg` | `COPY` via `copy_records_to_table` | Always on; atomic with exact row counts |
+| `psycopg` sync/async | `COPY` streaming `write_row` | Always on; atomic with exact row counts |
+| `psqlpy` | Binary `COPY` with `INSERT` fallback | Always on |
+| `adbc` | `adbc_ingest` | Driver-dependent; Flight SQL may fall back per row |
+| `duckdb` | register Arrow table, then `INSERT ... SELECT` | Single connection transaction |
+| `sqlite` / `aiosqlite` | `executemany` in one `BEGIN IMMEDIATE` | Atomic when the driver owns the transaction |
+| `oracledb` | Direct path load in Thin mode; `executemany` fallback | Set `enable_direct_path_load=False` to force fallback |
+| `pymysql`, `asyncmy`, `aiomysql`, `mysqlconnector` | `executemany`; opt-in `LOAD DATA LOCAL INFILE` | Requires feature and connection local-infile gate |
+| `bigquery` | Parquet load job; optional Storage Write API for appends | `enable_storage_write_api`; `overwrite=True` uses Parquet `WRITE_TRUNCATE` |
+| `spanner` | `insert_or_update` mutations; optional Batch Write API | `enable_batch_write_api`; Batch Write commits groups independently |
+| `mssql_python` | `cursor.bulkcopy()` | Driver-managed |
+| `arrow_odbc` | `bulk_insert_arrow` | Driver-managed |
+
+---
+
+## Security Gates
+
+MySQL `LOAD DATA LOCAL INFILE` reads client-side files. Enable it only when the server, connection, and SQLSpec adapter feature are all intentionally configured:
+
+- `pymysql`, `aiomysql`: `connection_config={"local_infile": True}` plus `driver_features={"enable_local_infile_bulk_load": True}`.
+- `asyncmy`: `allow_local_infile=True` is required before `local_infile=True` is honored.
+- `mysqlconnector`: `connection_config={"allow_local_infile": True}` plus the feature flag. Honor `allow_local_infile_in_path` when set.
+
+Oracle direct path load is the default in Thin mode when the connection exposes the Direct Path Load API. Thick-mode or unsupported connections fall back to `executemany()`.
+
+BigQuery Storage Write API is append-only in this surface. `overwrite=True` uses a Parquet load job instead.
+
+Spanner Batch Write API uses independently committed mutation groups. Treat it as high-throughput idempotent upsert behavior, not as a single transaction.
+
+---
+
+## Usage Rules
+
+- Use `load_from_records()` for in-memory data instead of hand-written `execute_many()` loops when ingest volume matters.
+- Use `load_from_arrow()` when the upstream step already produced Arrow.
+- Use `load_from_storage()` for staged files and cloud URIs. BigQuery requires `gs://` staging for load paths.
+- Check `config.storage_capabilities()` before building generic ingest tooling.
+- Keep adapter gates in configuration. Do not pass invented per-call flags to `load_from_arrow()`.

--- a/plugins/litestar/skills/sqlspec/references/data-dictionary.md
+++ b/plugins/litestar/skills/sqlspec/references/data-dictionary.md
@@ -1,6 +1,6 @@
 # SQLSpec Data Dictionary
 
-`sqlspec.data_dictionary` is the introspection layer that exposes `information_schema`-style metadata — table lists, column definitions, indexes, foreign keys, database version, feature flags — uniformly across every supported dialect. It is what the migration tracker uses to decide whether `ddl_migrations` needs schema upgrades, and what adapter-specific code uses to pick an optimal column type for a logical category (e.g. "give me the best JSON type this Postgres version can handle").
+`sqlspec.data_dictionary` is the introspection layer that exposes `information_schema`-style metadata -- table lists, column definitions, indexes, foreign keys, database version, feature flags, and native statistics where supported. It is what the migration tracker uses to decide whether `ddl_migrations` needs schema upgrades, and what adapter-specific code uses to pick an optimal column type for a logical category (e.g. "give me the best JSON type this Postgres version can handle").
 
 ## What It Is
 
@@ -17,7 +17,8 @@ Top-level exports in `sqlspec.data_dictionary.__init__`:
 
 - `DataDictionaryLoader`, `get_data_dictionary_loader()` — singleton that lazy-loads the per-dialect SQL queries from `sqlspec/data_dictionary/sql/<dialect>/*.sql`.
 - `get_dialect_config(dialect)`, `list_registered_dialects()`, `register_dialect(config)`, `normalize_dialect_name(dialect)` — the dialect registry.
-- `DialectConfig`, `FeatureFlags`, `FeatureVersions` — the static-config types in `sqlspec/data_dictionary/_types.py`.
+- `DialectConfig`, `FeatureFlags`, `FeatureVersions` — static-config types in `sqlspec/data_dictionary/_types.py`.
+- `TableMetadata`, `ColumnMetadata`, `IndexMetadata`, `ForeignKeyMetadata`, `TableStatisticsMetadata` — runtime metadata types exported from `sqlspec.data_dictionary`.
 
 `DialectConfig` fields (see `sqlspec/data_dictionary/_types.py`):
 
@@ -36,16 +37,17 @@ config = DialectConfig(
 
 `FeatureFlags` is a `TypedDict` with keys like `supports_arrays`, `supports_clustering`, `supports_cte`, `supports_json`, `supports_returning`, `supports_upsert`, `supports_uuid`, `supports_window_functions`. `FeatureVersions` maps a subset of those to `VersionInfo(major, minor, patch)` minimums.
 
-Runtime metadata types live in `sqlspec.typing` and are `TypedDict`s:
+Runtime metadata types live in `sqlspec.data_dictionary`:
 
 - `TableMetadata` — `schema_name`, `table_name`, `table_type`, `table_catalog`.
 - `ColumnMetadata` — `column_name`, `data_type`, `is_nullable`, `column_default`, `ordinal_position`, `max_length`, `numeric_precision`, `numeric_scale`, `is_primary`, `is_unique`, `extra`.
 - `IndexMetadata` — `index_name`, `columns`, `is_unique`, `is_primary`.
 - `ForeignKeyMetadata` — source/target columns and schemas.
+- `TableStatisticsMetadata` — `catalog_name`, `schema_name`, `table_name`, optional `column_name`, `statistic_key`, `statistic_name`, `statistic_value`, `is_approximate`.
 
 ## Dialect Coverage
 
-Eight dialect modules register a `DialectConfig` when imported (`sqlspec/data_dictionary/dialects/__init__.py`):
+Dialect modules register a `DialectConfig` when imported (`sqlspec/data_dictionary/dialects/__init__.py`):
 
 | Dialect module | Exported config |
 | --- | --- |
@@ -53,6 +55,7 @@ Eight dialect modules register a `DialectConfig` when imported (`sqlspec/data_di
 | `cockroachdb.py` | `COCKROACHDB_CONFIG` |
 | `duckdb.py` | `DUCKDB_CONFIG` |
 | `mysql.py` | `MYSQL_CONFIG` |
+| `mssql.py` | `MSSQL_CONFIG` |
 | `oracle.py` | `ORACLE_CONFIG` |
 | `postgres.py` | `POSTGRES_CONFIG` |
 | `spanner.py` | `SPANNER_CONFIG` |
@@ -96,6 +99,8 @@ Available driver-side methods (async signatures shown; sync drivers expose the s
 - `await driver.data_dictionary.get_columns(driver, table=None, schema=None)` → `list[ColumnMetadata]`
 - `await driver.data_dictionary.get_indexes(driver, table=None, schema=None)` → `list[IndexMetadata]`
 - `await driver.data_dictionary.get_foreign_keys(driver, table=None, schema=None)` → `list[ForeignKeyMetadata]`
+
+ADBC adds an adapter-specific `get_statistics(driver, table, schema=None)` method that wraps the native `adbc_get_statistics` API and returns `list[TableStatisticsMetadata]`. It is separate from the shared data dictionary surface because SQLSpec does not define a portable SQL statistics contract. Unsupported ADBC drivers raise `OperationalError`; PostgreSQL provides approximate native statistics, SQLite and DuckDB currently raise, Flight SQL behavior is server-dependent, and BigQuery is unverified.
 
 ### Sync
 

--- a/plugins/litestar/skills/sqlspec/references/driver_api.md
+++ b/plugins/litestar/skills/sqlspec/references/driver_api.md
@@ -2,90 +2,131 @@
 
 ## Overview
 
-All database interactions go through driver adapters. Async adapters extend `AsyncDriverAdapterBase`, sync adapters extend `SyncDriverAdapterBase`. Both expose the same method surface with sync/async variants.
+All database interactions go through driver adapters. Async adapters extend `AsyncDriverAdapterBase`; sync adapters extend `SyncDriverAdapterBase`. The public method surface is parallel: async drivers use `await`, sync drivers do not.
+
+Use the current method names. `select_many()` and `copy_from_arrow()` are not public SQLSpec APIs in `v0.51.0`.
+
+Bind normal query parameters as variadic positional arguments. Use `await db_session.select("... WHERE id = $1", user_id, schema_type=User)`, not `await db_session.select(..., [user_id], ...)`. Keep list or tuple containers for real batch/data payloads such as `execute_many()` parameter sets or `load_from_records()` rows.
 
 ---
 
 ## Query Methods
 
-### select_value() -- Single Scalar
+### select() / fetch() -- Multiple Rows
 
-Returns a single scalar value from the first column of the first row:
+Return a list of rows. `fetch()` is an alias for users coming from asyncpg-style naming.
 
 ```python
-count = await db_session.select_value("SELECT COUNT(*) FROM users")
-# Returns: 42
-
-name = await db_session.select_value(
-    "SELECT name FROM users WHERE id = $1", [user_id]
+users = await db_session.select(
+    "SELECT * FROM users WHERE active = $1",
+    True,
+    schema_type=User,
 )
-# Returns: "Alice"
 ```
+
+When `schema_type` is omitted, rows are dicts. `schema_type` supports Pydantic models, dataclasses, msgspec structs, attrs classes, and TypedDicts.
 
 ### select_one() -- Single Row (Strict)
 
-Returns exactly one row. Raises `NotFoundError` if no rows, `MultipleResultsError` if more than one:
+Return exactly one row. SQLSpec maps the no-row case to `NotFoundError`; multiple rows remain a `ValueError` from result cardinality validation.
 
 ```python
 user = await db_session.select_one(
     "SELECT * FROM users WHERE id = $1",
-    [user_id],
+    user_id,
     schema_type=User,
 )
 ```
 
 ### select_one_or_none() -- Single Row (Optional)
 
-Returns one row or `None`. Raises `MultipleResultsError` if more than one:
+Return one row or `None`. More than one row raises `ValueError`.
 
 ```python
 user = await db_session.select_one_or_none(
     "SELECT * FROM users WHERE email = $1",
-    [email],
+    email,
     schema_type=User,
 )
-if user is None:
-    # Handle not found
-    ...
 ```
 
-### select_many() -- Multiple Rows
+### select_value() / select_value_or_none() -- Scalar Values
 
-Returns a list of rows:
+Use `value_type=` to narrow and coerce the returned scalar.
 
 ```python
-users = await db_session.select_many(
-    "SELECT * FROM users WHERE active = $1",
-    [True],
-    schema_type=User,
+count = await db_session.select_value(
+    "SELECT COUNT(*) FROM users WHERE active = $1",
+    True,
+    value_type=int,
 )
 ```
 
 ### select_with_total() -- Pagination
 
-Returns rows plus total count for pagination. Executes a windowed count query:
+Return rows plus total count for pagination. Use `count_with_window=True` only when the target dialect and query shape support the window-count path.
 
 ```python
 users, total = await db_session.select_with_total(
     "SELECT * FROM users WHERE active = $1 ORDER BY name LIMIT $2 OFFSET $3",
-    [True, 20, 40],
+    True,
+    20,
+    40,
     schema_type=User,
 )
-# total = 156 (total matching rows, ignoring LIMIT/OFFSET)
-# users = [...] (up to 20 rows)
 ```
 
-### select_to_arrow() -- Arrow Result
+### select_stream() / fetch_stream() -- Row Streaming
 
-Returns an Arrow table. Zero-copy on ADBC and DuckDB adapters:
+Return a context-managed row stream fetched in chunks. Use `native_only=True` when eager fallback would be incorrect for memory use.
 
 ```python
-arrow_table = await db_session.select_to_arrow(
-    "SELECT * FROM large_dataset WHERE region = $1",
-    [region],
-)
-# arrow_table is a pyarrow.Table
+async with db_session.select_stream(
+    "SELECT id, payload FROM events ORDER BY id",
+    chunk_size=1_000,
+    native_only=True,
+) as stream:
+    async for row in stream:
+        await process(row)
 ```
+
+Native row streaming support is discoverable via `config.supports_native_row_streaming`.
+
+Native paths:
+
+- `psycopg` / `cockroach_psycopg`: server-side named cursors.
+- `asyncpg` / `cockroach_asyncpg`: cursors inside a stream-owned transaction.
+- `pymysql`, `aiomysql`, `asyncmy`: `SSCursor`.
+- `mysqlconnector`: unbuffered cursors.
+- `sqlite`, `aiosqlite`, `oracledb`: chunked `fetchmany()`.
+- `psqlpy`: server-side cursor with `array_size`.
+- `bigquery`: page-wise result iteration.
+
+Eager fallback only: `adbc`, `duckdb`, `mssql_python`, `arrow_odbc`, and `spanner`.
+
+Lifetime rules:
+
+- Close or exhaust the stream before issuing another statement on the same connection.
+- PostgreSQL-family streams open their own transaction or savepoint and close it when the stream closes.
+- MySQL unbuffered cursors drain remaining rows when closed mid-iteration.
+- BigQuery `page_size` is advisory.
+- Oracle streams return raw driver values for LOB columns.
+- If iteration raises on PostgreSQL drivers, roll back before reusing the connection.
+
+### select_to_arrow() / fetch_to_arrow() -- Arrow Result
+
+Return an `ArrowResult`, not a bare `pyarrow.Table`. Use `return_format=` to choose `table`, `batch`, `batches`, or `reader`.
+
+```python
+arrow_result = await db_session.select_to_arrow(
+    "SELECT * FROM large_dataset WHERE region = $1",
+    region,
+    return_format="reader",
+    batch_size=10_000,
+)
+```
+
+Adapters without native Arrow export use dict-to-Arrow conversion. Add `native_only=True` only when the selected adapter has a native Arrow override and fallback would hide a performance or memory bug.
 
 ---
 
@@ -93,20 +134,21 @@ arrow_table = await db_session.select_to_arrow(
 
 ### execute() -- Single Statement
 
-Execute a DML statement (INSERT, UPDATE, DELETE) and return result with rowcount:
+Execute a statement and return `SQLResult`.
 
 ```python
 result = await db_session.execute(
     "INSERT INTO users (name, email) VALUES ($1, $2) RETURNING id",
-    ["Alice", "alice@example.com"],
+    "Alice",
+    "alice@example.com",
 )
-print(result.rowcount)        # 1
-print(result.last_insert_id)  # UUID or int
+print(result.rows_affected)
+print(result.last_inserted_id)
 ```
 
 ### execute_many() -- Batch DML
 
-Execute a statement with multiple parameter sets:
+Execute one statement with multiple parameter sets. Use tuple/list parameters for positional styles and mapping parameters for named styles.
 
 ```python
 result = await db_session.execute_many(
@@ -114,11 +156,56 @@ result = await db_session.execute_many(
     [
         ("Alice", "alice@example.com"),
         ("Bob", "bob@example.com"),
-        ("Carol", "carol@example.com"),
     ],
 )
-print(result.rowcount)  # 3
+print(result.rows_affected)
 ```
+
+For high-volume ingest, prefer `load_from_records()` or `load_from_arrow()` when the adapter supports native ingest.
+
+---
+
+## Storage Bridge Methods
+
+### load_from_arrow()
+
+Load an Arrow table or coercible Arrow source into a target table through the adapter's native ingest path.
+
+```python
+job = await db_session.load_from_arrow("orders", arrow_result, overwrite=False)
+print(job.telemetry["rows_processed"])
+```
+
+### load_from_storage()
+
+Load a staged artifact, local path, or cloud URI into a target table.
+
+```python
+job = await db_session.load_from_storage(
+    "orders",
+    "gs://bucket/orders.parquet",
+    file_format="parquet",
+)
+```
+
+### load_from_records()
+
+Normalize in-memory mapping or positional records into Arrow, then route through `load_from_arrow()`.
+
+```python
+await db_session.load_from_records(
+    "orders",
+    [{"id": 1, "total": 9.99}, {"id": 2, "total": 4.50}],
+)
+
+await db_session.load_from_records(
+    "orders",
+    [(3, 1.0), (4, 2.0)],
+    columns=["id", "total"],
+)
+```
+
+Empty records, mismatched mapping keys, and positional width mismatches raise `ImproperConfigurationError`.
 
 ---
 
@@ -126,86 +213,44 @@ print(result.rowcount)  # 3
 
 ### begin() / commit() / rollback()
 
-Explicit transaction control:
+Use explicit transaction control only when a higher-level session or framework commit mode is not managing the transaction.
 
 ```python
 await db_session.begin()
 try:
-    await db_session.execute("UPDATE accounts SET balance = balance - $1 WHERE id = $2", [100, from_id])
-    await db_session.execute("UPDATE accounts SET balance = balance + $1 WHERE id = $2", [100, to_id])
+    await db_session.execute("UPDATE accounts SET balance = balance - $1 WHERE id = $2", 100, from_id)
+    await db_session.execute("UPDATE accounts SET balance = balance + $1 WHERE id = $2", 100, to_id)
     await db_session.commit()
 except Exception:
     await db_session.rollback()
     raise
 ```
 
-### session() Context Manager
+### provide_session() Context Manager
 
-Preferred pattern for transaction scoping:
-
-```python
-async with db_session.session() as session:
-    await session.execute("INSERT INTO logs (msg) VALUES ($1)", ["started"])
-    await session.execute("UPDATE jobs SET status = $1 WHERE id = $2", ["running", job_id])
-    # Auto-commits on successful exit, auto-rolls-back on exception
-```
-
----
-
-## Schema Mapping with schema_type
-
-All select methods accept a `schema_type` parameter for automatic row mapping to Pydantic models or msgspec structs:
+Use `SQLSpec.provide_session(config)` or `config.provide_session()` for lifecycle scoping. Framework integrations usually provide this per request.
 
 ```python
-from pydantic import BaseModel
-
-class User(BaseModel):
-    id: int
-    name: str
-    email: str
-
-# Pydantic model mapping
-user = await db_session.select_one(
-    "SELECT id, name, email FROM users WHERE id = $1",
-    [user_id],
-    schema_type=User,
-)
-# user is a User instance
+async with config.provide_session() as session:
+    await session.execute("INSERT INTO logs (msg) VALUES ($1)", "started")
 ```
-
-```python
-import msgspec
-
-class User(msgspec.Struct):
-    id: int
-    name: str
-    email: str
-
-# msgspec struct mapping (faster serialization)
-user = await db_session.select_one(
-    "SELECT id, name, email FROM users WHERE id = $1",
-    [user_id],
-    schema_type=User,
-)
-```
-
-When `schema_type` is omitted, rows are returned as dicts.
 
 ---
 
 ## Method Summary
 
-| Method | Returns | Raises |
+| Method | Returns | Notes |
 | --- | --- | --- |
-| `select_value(sql, params)` | `Any` (scalar) | `NotFoundError` if no rows |
-| `select_one(sql, params, schema_type=)` | `T` or `dict` | `NotFoundError`, `MultipleResultsError` |
-| `select_one_or_none(sql, params, schema_type=)` | `T \| None` | `MultipleResultsError` |
-| `select_many(sql, params, schema_type=)` | `list[T]` or `list[dict]` | -- |
-| `select_with_total(sql, params, schema_type=)` | `tuple[list[T], int]` | -- |
-| `select_to_arrow(sql, params)` | `pyarrow.Table` | -- |
-| `execute(sql, params)` | `ExecutionResult` | adapter-specific |
-| `execute_many(sql, params_list)` | `ExecutionResult` | adapter-specific |
-| `begin()` | `None` | -- |
-| `commit()` | `None` | -- |
-| `rollback()` | `None` | -- |
-| `session()` | context manager | -- |
+| `select()` / `fetch()` | `list[T]` or `list[dict]` | Multiple rows |
+| `select_one()` / `fetch_one()` | `T` or `dict` | No row becomes `NotFoundError`; multiple rows raise `ValueError` |
+| `select_one_or_none()` / `fetch_one_or_none()` | `T \| dict \| None` | Optional row |
+| `select_value()` / `fetch_value()` | Scalar | Optional `value_type=` coercion |
+| `select_value_or_none()` / `fetch_value_or_none()` | Scalar or `None` | Optional scalar |
+| `select_with_total()` / `fetch_with_total()` | `tuple[list[T], int]` | Pagination |
+| `select_stream()` / `fetch_stream()` | `SyncRowStream` / `AsyncRowStream` | Context-managed chunk stream |
+| `select_to_arrow()` / `fetch_to_arrow()` | `ArrowResult` | `return_format="table" \| "batch" \| "batches" \| "reader"` |
+| `execute()` | `SQLResult` | Check `rows_affected`, `last_inserted_id`, `metadata` |
+| `execute_many()` | `SQLResult` | Batch parameters |
+| `load_from_arrow()` | `StorageBridgeJob` | Native ingest where supported |
+| `load_from_storage()` | `StorageBridgeJob` | Staged files/cloud URIs |
+| `load_from_records()` | `StorageBridgeJob` | Records normalized through Arrow |

--- a/plugins/litestar/skills/sqlspec/references/extensions.md
+++ b/plugins/litestar/skills/sqlspec/references/extensions.md
@@ -39,16 +39,17 @@ from litestar import get, post
 
 @get("/users")
 async def list_users(db_session: AsyncpgDriver) -> list[dict]:
-    result = await db_session.select_many("SELECT * FROM users")
+    result = await db_session.select("SELECT * FROM users")
     return result
 
 @post("/users")
 async def create_user(db_session: AsyncpgDriver, data: UserCreate) -> dict:
     result = await db_session.execute(
         "INSERT INTO users (name, email) VALUES ($1, $2) RETURNING id",
-        [data.name, data.email],
+        data.name,
+        data.email,
     )
-    return {"id": result.last_insert_id}
+    return {"id": result.last_inserted_id}
 ```
 
 ### Session Store Integration
@@ -129,7 +130,7 @@ db_ext = SQLSpecPlugin(sqlspec=spec, app=app)
 @app.get("/users")
 async def list_users(request: Request):
     db_session = db_ext.get_session(request)
-    result = await db_session.select_many("SELECT * FROM users")
+    result = await db_session.select("SELECT * FROM users")
     return result
 ```
 
@@ -172,7 +173,7 @@ All adapters wrap exceptions using `wrap_exceptions` referencing static mappings
 - `AdapterError`: Generic connectivity or execution issues.
 - `IntegrityError`: Constraint and uniqueness violations.
 - `NotFoundError`: Expected row not found.
-- `MultipleResultsError`: Expected single row but got multiple.
+- `ValueError`: `select_one()` and `select_one_or_none()` received multiple rows.
 
 ### Two-Tier Event Reporting
 

--- a/plugins/litestar/skills/sqlspec/references/fastapi-integration.md
+++ b/plugins/litestar/skills/sqlspec/references/fastapi-integration.md
@@ -144,7 +144,7 @@ SessionDep = Annotated[AsyncpgDriver, Depends(db_plugin.provide_session())]
 
 @app.get("/orders/{order_id}")
 async def get_order(order_id: int, db: SessionDep) -> dict[str, Any]:
-    rows = await db.select("SELECT * FROM orders WHERE id = $1", [order_id])
+    rows = await db.select("SELECT * FROM orders WHERE id = $1", order_id)
     return {"order": rows[0] if rows else None}
 ```
 
@@ -454,14 +454,16 @@ async def create_order(payload: dict[str, Any], db: SessionDep) -> dict[str, Any
         raise HTTPException(status_code=422, detail="customer_id and amount required")
     result = await db.execute(
         "INSERT INTO orders (customer_id, status, amount) VALUES ($1, $2, $3) RETURNING id",
-        [payload["customer_id"], "pending", payload["amount"]],
+        payload["customer_id"],
+        "pending",
+        payload["amount"],
     )
     return {"id": result.one()["id"]}
 
 
 @app.get("/orders/{order_id}")
 async def get_order(order_id: int, db: SessionDep) -> dict[str, Any]:
-    rows = await db.select("SELECT * FROM orders WHERE id = $1", [order_id])
+    rows = await db.select("SELECT * FROM orders WHERE id = $1", order_id)
     if not rows:
         raise HTTPException(status_code=404, detail="order not found")
     return {"order": rows[0]}

--- a/plugins/litestar/skills/sqlspec/references/flask-integration.md
+++ b/plugins/litestar/skills/sqlspec/references/flask-integration.md
@@ -208,7 +208,9 @@ def create_order() -> tuple[dict, int]:
     db: SqliteDriver = plugin.get_session()
     result = db.execute(
         "INSERT INTO orders (customer_id, status, amount) VALUES (?, ?, ?) RETURNING id",
-        [payload["customer_id"], "pending", payload["amount"]],
+        payload["customer_id"],
+        "pending",
+        payload["amount"],
     )
     return {"id": result.one()["id"]}, 201
 
@@ -396,7 +398,9 @@ def create_app() -> Flask:
         db: SqliteDriver = plugin.get_session()
         result = db.execute(
             "INSERT INTO orders (customer_id, status, amount) VALUES (?, ?, ?) RETURNING id",
-            [payload["customer_id"], "pending", payload["amount"]],
+            payload["customer_id"],
+            "pending",
+            payload["amount"],
         )
         return {"id": result.one()["id"]}, 201
 

--- a/plugins/litestar/skills/sqlspec/references/loader.md
+++ b/plugins/litestar/skills/sqlspec/references/loader.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`SQLFileLoader` loads SQL statements from external files, supporting metadata directives, multiple search paths, and content caching with checksums.
+`SQLFileLoader` loads SQL statements from external files, supporting metadata directives, declared parameter annotations, multiple search paths, and content caching with checksums.
 
 ---
 
@@ -16,7 +16,7 @@ loader.load_sql("./sql", "./sql/queries")
 
 # Load a named query
 stmt = loader.get_sql("get-user-by-id")
-result = await db_session.select_one(stmt, [user_id], schema_type=User)
+result = await db_session.select_one(stmt, user_id, schema_type=User)
 ```
 
 ---
@@ -40,6 +40,7 @@ WHERE id = $1
 | --- | --- | --- |
 | `-- name:` | Yes | Unique identifier for the query |
 | `-- dialect:` | No | Source dialect for sqlglot parsing |
+| `-- param:` | No | Declared parameter metadata and validation |
 | `-- description:` | No | Human-readable description |
 | `-- result:` | No | Expected result type hint (`one`, `many`, `value`, `affected`) |
 
@@ -58,6 +59,38 @@ SELECT COUNT(*) FROM users
 -- dialect: postgres
 SELECT * FROM users WHERE email = $1
 ```
+
+---
+
+## Declared Parameters
+
+Use `-- param:` lines in the leading comment block for named SQL that crosses service boundaries:
+
+```sql
+-- name: get-team-by-name
+-- param: name str  The team name to look up
+SELECT id, name FROM teams WHERE name = :name
+
+-- name: list-teams
+-- param: name str?  Optional team name filter
+SELECT id, name FROM teams
+WHERE (:name IS NULL OR name = :name)
+ORDER BY id
+```
+
+Grammar: `-- param: <name> <type> [description]`. Append `?` to the type or end the description with `(optional)` to mark a named parameter optional.
+
+Behavior:
+
+- No `-- param:` lines means no declaration validation and no behavior change.
+- Required declarations must be supplied at execution time.
+- Missing optional named declarations bind `None`; the SQL must express the intended nullable condition.
+- Declared names are cross-checked against actual placeholders at load time.
+- Type strings from the allowlist are checked at execution time; unresolved type strings are documentation-only.
+- Extra parameters are allowed because filters may add `limit`, `offset`, and related parameters.
+- Malformed `-- param:` lines warn and are skipped by default. Pass `strict_parameter_annotations=True` to `SQLFileLoader` to make malformed annotations fail.
+
+Introspect declarations with `spec.get_query_parameters(name)` or `spec.get_sql(name).declared_parameters`.
 
 ---
 
@@ -133,9 +166,9 @@ loader.load_sql("./sql")
 
 # Load and execute
 stmt = loader.get_sql("list-active-users")
-users = await db_session.select_many(stmt, schema_type=User)
+users = await db_session.select(stmt, schema_type=User)
 
 # Load with parameter override
 stmt = loader.get_sql("get-user-by-id")
-user = await db_session.select_one(stmt, [user_id], schema_type=User)
+user = await db_session.select_one(stmt, user_id, schema_type=User)
 ```

--- a/plugins/litestar/skills/sqlspec/references/patterns.md
+++ b/plugins/litestar/skills/sqlspec/references/patterns.md
@@ -5,7 +5,7 @@
 `SQLSpecAsyncService` ships upstream in `sqlspec.service`. Use it as the base class for app services that wrap an async driver with helpers like `paginate`, `get_one`, `exists`, and `begin_transaction`.
 
 ```python
-from sqlspec.core.filters import OffsetPagination
+from sqlspec.core.filters import LimitOffsetFilter, OffsetPagination
 from sqlspec.service import SQLSpecAsyncService
 
 
@@ -13,9 +13,8 @@ class UserService(SQLSpecAsyncService):
     async def list_users(self, page: int = 1, page_size: int = 20) -> OffsetPagination[User]:
         return await self.paginate(
             "SELECT * FROM users ORDER BY created_at DESC",
+            LimitOffsetFilter(limit=page_size, offset=page_size * (page - 1)),
             schema_type=User,
-            page=page,
-            page_size=page_size,
         )
 
     async def get_user(self, user_id: str) -> User:
@@ -35,11 +34,13 @@ class UserService(SQLSpecAsyncService):
         async with self.begin_transaction() as tx:
             await tx.execute(
                 "UPDATE accounts SET balance = balance - $1 WHERE id = $2",
-                [amount, from_id],
+                amount,
+                from_id,
             )
             await tx.execute(
                 "UPDATE accounts SET balance = balance + $1 WHERE id = $2",
-                [amount, to_id],
+                amount,
+                to_id,
             )
 ```
 
@@ -71,7 +72,7 @@ result = await db_session.execute_many(
     "INSERT INTO users (name, email) VALUES ($1, $2)",
     users,
 )
-print(f"Inserted {result.rowcount} rows")
+print(f"Inserted {result.rows_affected} rows")
 ```
 
 ### Batch with Dicts
@@ -128,7 +129,7 @@ query = (
 )
 
 stmt = query.to_statement()
-rows = await db_session.select_many(stmt, schema_type=DeptSummary)
+rows = await db_session.select(stmt, schema_type=DeptSummary)
 ```
 
 ---

--- a/plugins/litestar/skills/sqlspec/references/performance.md
+++ b/plugins/litestar/skills/sqlspec/references/performance.md
@@ -1,0 +1,114 @@
+# SQLSpec Performance & Cloud Controls
+
+## Overview
+
+SQLSpec keeps performance controls explicit. Configure them through adapter `connection_config`, `driver_features`, `statement_config`, or the documented session providers. Do not invent new driver methods for cloud job/session control.
+
+---
+
+## Bounded Async Bridge
+
+`sqlspec.utils.sync_tools.async_()` wraps blocking callables for async code. In `v0.51.0`, SQLSpec uses a process-local managed `ThreadPoolExecutor` capped by default.
+
+Use an explicit executor when the call site owns the pool:
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+
+from sqlspec.utils.sync_tools import async_
+
+executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="sqlspec")
+run_query = async_(blocking_query, executor=executor)
+result = await run_query()
+```
+
+Set the managed pool limit before the first bridge call:
+
+```bash
+export SQLSPEC_ASYNC_THREAD_LIMIT=8
+```
+
+Programmatic controls:
+
+- `enable_default_async_thread_pool(max_workers=8)`
+- `set_default_async_executor(executor)`
+- `get_default_async_executor()`
+- `shutdown_default_async_executor(wait=False)`
+
+Precedence is explicit: `async_(fn, executor=...)` wins over `set_default_async_executor()`, which wins over SQLSpec's managed pool. Only `ThreadPoolExecutor` instances are accepted because SQLSpec preserves `contextvars` through bridge calls.
+
+---
+
+## Statement Cache And Fetch Tuning
+
+| Adapter | Knob | Use when | Avoid when |
+| --- | --- | --- | --- |
+| All drivers | `driver_features={"sqlspec_statement_cache_size": N}` | Same raw SQL text runs repeatedly with simple parameters | SQL text is high-cardinality or DDL changes affect result shapes |
+| `asyncpg` | `connection_config={"statement_cache_size": N}` | Long-lived PostgreSQL sessions repeat parameterized statements | PgBouncer transaction/statement pooling or frequent schema churn |
+| `psycopg` | `connection_config={"prepare_threshold": N}` | Repeated queries amortize server-side planning | Rarely repeated queries or connection middleware changes sessions |
+| `oracledb` | `connection_config={"stmtcachesize": N}` | Same Oracle statement text repeats frequently | Statement text has high cardinality or memory pressure dominates |
+| `oracledb` | `driver_features={"arraysize": N, "prefetchrows": N}` | Large result sets spend time on network round trips | Single-row lookups or very wide rows dominate |
+| `oracledb` | `driver_features={"fetch_lobs": False, "fetch_decimals": True}` | You need native LOB or NUMBER fetch representation | Application expects SQLSpec defaults |
+| `bigquery` | `driver_features={"query_page_size": N, "query_max_results": N}` | Bound page size or total rows for SELECT result fetching | DML and scripts; these controls apply to result fetching |
+| `arrow_odbc` | `driver_features={"chunk_size": N, "max_bytes_per_batch": N}` | Tune Arrow batch memory and round trips | Downstream requires a fixed batch shape |
+| `arrow_odbc` | `driver_features={"max_text_size": N, "max_binary_size": N, "fetch_concurrently": bool}` | Bound text/binary columns or improve high-latency fetches | Truncation is unacceptable or the ODBC source is unstable under concurrent fetch |
+
+Measure before changing defaults. Cache knobs help repeated statement text on stable sessions; fetch knobs tune network and memory after the query plan is already correct.
+
+---
+
+## BigQuery Job Controls
+
+Configure BigQuery job behavior through `BigQueryConfig.driver_features`.
+
+| Feature | Effect |
+| --- | --- |
+| `job_retry_deadline` | Total seconds for retry construction; `<= 0` disables the BigQuery job retry wrapper |
+| `job_result_timeout` | Bounds waits on `QueryJob.result()` and load-job completion |
+| `request_timeout` | Bounds the initial BigQuery API request; defaults from `job_result_timeout` when numeric |
+| `use_query_and_wait` | Uses `Client.query_and_wait()` for simple query execution |
+| `query_page_size` | Passed to `QueryJob.result()` for SELECT result fetching |
+| `query_max_results` | Total row cap passed to `QueryJob.result()` for SELECT result fetching |
+| `enable_storage_write_api` | Uses Storage Write API for `load_from_arrow(..., overwrite=False)` appends when available |
+
+Use the normal SQLSpec calls: `execute()`, `select()`, `select_to_arrow()`, `select_to_storage()`, `load_from_arrow()`, and `load_from_storage()`. SQLSpec does not expose `execute_with_job()` or `export_table_to_storage()`.
+
+Use `job_retry_deadline=0` for emulators or endpoints where retrying unsupported jobs extends failure time.
+
+---
+
+## Spanner Request And Session Controls
+
+Configure defaults through `SpannerSyncConfig.driver_features`:
+
+- `request_options` -- forwarded to `execute_sql()`, `execute_update()`, and `batch_update()`.
+- `directed_read_options` -- forwarded only to read calls using `execute_sql()`.
+- `retry` and `timeout` -- forwarded to statement execution calls.
+- `enable_batch_write_api` -- routes `load_from_arrow()` through Spanner Batch Write API for high-throughput mutation groups when `overwrite=False`.
+
+Per-call overrides use the existing driver methods:
+
+```python
+result = driver.execute(
+    "SELECT id FROM users WHERE id = @id",
+    {"id": "u-1"},
+    request_options={"request_tag": "users.lookup"},
+    directed_read_options=directed_read_options,
+    timeout=10.0,
+)
+```
+
+Session-scoped controls belong on `provide_session()`:
+
+```python
+with config.provide_session(
+    request_options={"transaction_tag": "orders.write"},
+    retry=retry,
+    timeout=20.0,
+) as driver:
+    driver.execute("UPDATE orders SET status = @status WHERE id = @id", params)
+```
+
+Use `provide_read_session()` for single-use snapshot reads. Use `provide_session()` or `provide_write_session()` for DDL, DML, and write-capable transactions.
+
+SQLSpec does not expose public `execute_with_options()`, `execute_partitioned_dml()`, `apply_mutations()`, or `provide_batch_snapshot()` methods.

--- a/plugins/litestar/skills/sqlspec/references/query_builder.md
+++ b/plugins/litestar/skills/sqlspec/references/query_builder.md
@@ -57,7 +57,7 @@ filters = [
 ]
 
 # The driver applies filters to the AST before execution
-rows = await db_session.select_many(base, *filters, schema_type=User)
+rows = await db_session.select(base, *filters, schema_type=User)
 
 # Or with pagination (returns items + total count)
 rows, total = await db_session.select_with_total(base, *filters, schema_type=User)
@@ -97,7 +97,7 @@ query = (
 | `.join(table, on=)` | INNER JOIN | `.join("orders", on="users.id = orders.user_id")` |
 | `.left_join(table, on=)` | LEFT JOIN | `.left_join("profiles", on="users.id = profiles.user_id")` |
 | `.where(expr)` | WHERE clause (AND-combined) | `.where("active = true")` |
-| `.where_eq(**kw)` | WHERE col = value (parameterized) | `.where_eq(status="active")` |
+| `.where_eq(column, value)` | WHERE col = value (parameterized) | `.where_eq("status", "active")` |
 | `.group_by(*cols)` | GROUP BY | `.group_by("department")` |
 | `.having(expr)` | HAVING clause | `.having("COUNT(*) > 5")` |
 | `.order_by(*exprs)` | ORDER BY | `.order_by("created_at DESC")` |
@@ -193,7 +193,7 @@ query = (
 query = (
     sql.update("users")
     .set(name="Bob", updated_at="now()")
-    .where_eq(id=1)
+    .where_eq("id", 1)
     .returning("id", "name")
 )
 
@@ -215,7 +215,7 @@ query = (
 query = (
     sql.delete()
     .from_("users")
-    .where_eq(id=1)
+    .where_eq("id", 1)
     .returning("id")
 )
 ```
@@ -248,7 +248,7 @@ query = sql.select("*").from_("users").where_eq("active", True)
 stmt = query.to_statement()
 
 # Execute via driver
-rows = await db_session.select_many(stmt, schema_type=User)
+rows = await db_session.select(stmt, schema_type=User)
 ```
 
 ### .compile(dialect=)

--- a/plugins/litestar/skills/sqlspec/references/service-patterns.md
+++ b/plugins/litestar/skills/sqlspec/references/service-patterns.md
@@ -92,7 +92,7 @@ Decision table:
 | A count or single cell | `select_value` |
 | One mapped object, must exist | `select_one` / `get_one` |
 | One mapped object, may be absent | `select_one_or_none` |
-| List of rows | `select_many` (via driver) or `paginate` (via service) |
+| List of rows | `select()` (via driver) or `paginate` (via service) |
 | INSERT/UPDATE/DELETE (no return) | `execute` |
 
 Example method combining `get_one` with a named template:

--- a/plugins/litestar/skills/sqlspec/references/starlette-integration.md
+++ b/plugins/litestar/skills/sqlspec/references/starlette-integration.md
@@ -289,7 +289,7 @@ async def list_orders(request: Request) -> JSONResponse:
     db: AsyncpgDriver = db_plugin.get_session(request)
     rows = await db.select(
         "SELECT id, status, amount FROM orders WHERE status = $1 ORDER BY id",
-        ["pending"],
+        "pending",
     )
     return JSONResponse({"orders": rows})
 
@@ -299,7 +299,9 @@ async def create_order(request: Request) -> JSONResponse:
     db: AsyncpgDriver = db_plugin.get_session(request)
     result = await db.execute(
         "INSERT INTO orders (customer_id, status, amount) VALUES ($1, $2, $3) RETURNING id",
-        [payload["customer_id"], "pending", payload["amount"]],
+        payload["customer_id"],
+        "pending",
+        payload["amount"],
     )
     return JSONResponse({"id": result.one()["id"]}, status_code=201)
 

--- a/plugins/litestar/skills/sqlspec/references/storage.md
+++ b/plugins/litestar/skills/sqlspec/references/storage.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-SQLSpec provides adapter-specific storage implementations for three integration points: ADK stores, event channel backends, and Litestar session stores. All are configured through the `extension_config` dict on adapter configs.
+SQLSpec provides adapter-specific storage implementations for Litestar session stores, event channel backends, and ADK session/event plus memory stores. Artifact service contracts are available under ADK, but adapter-specific concrete artifact metadata stores are deployment-provided. All integrations are configured through the `extension_config` dict on adapter configs.
 
 ---
 
@@ -18,9 +18,9 @@ config = AsyncpgConfig(
     connection_config={"dsn": "postgresql://localhost/app"},
     extension_config={
         "adk": {
-            "session_table": "adk_sessions",
-            "events_table": "adk_events",
-            "memory_table": "adk_memory_entries",
+            "session_table": "adk_session",
+            "events_table": "adk_event",
+            "memory_table": "adk_memory",
             "memory_use_fts": True,
         }
     },
@@ -34,11 +34,13 @@ await memory_store.ensure_tables()
 
 ### Available ADK Stores
 
-Every ADK-supported adapter provides its own store implementation. The stores handle:
+ADK-supported adapters are `asyncpg`, `psycopg`, `psqlpy`, `cockroach_asyncpg`, `cockroach_psycopg`, `aiomysql`, `asyncmy`, `mysqlconnector`, `pymysql`, `aiosqlite`, `sqlite`, `oracledb`, `duckdb`, `adbc`, and `spanner`. These stores handle:
 
 - Session rows and event history for `SQLSpecSessionService`
 - Memory rows for `SQLSpecMemoryService` / `SQLSpecSyncMemoryService`
 - Adapter-specific JSON, FTS, and transaction optimizations
+
+BigQuery is not an ADK backend. Use Spanner or an OLTP adapter for Google ADK session/event storage.
 
 ---
 
@@ -131,9 +133,9 @@ config = AsyncpgConfig(
         },
         # ADK session/event and memory stores
         "adk": {
-            "session_table": "adk_sessions",
-            "events_table": "adk_events",
-            "memory_table": "adk_memory_entries",
+            "session_table": "adk_session",
+            "events_table": "adk_event",
+            "memory_table": "adk_memory",
             "memory_use_fts": True,
         },
     },

--- a/plugins/litestar/skills/sqlspec/references/vector-search.md
+++ b/plugins/litestar/skills/sqlspec/references/vector-search.md
@@ -237,6 +237,6 @@ The `<=>` operator returns cosine distance (0 = identical, 2 = opposite); `1 - (
 
 ## Shared Styleguide Baseline
 
-- [`../litestar-styleguide/references/general.md`](../litestar-styleguide/references/general.md) — Cross-language baseline
-- [`../litestar-styleguide/references/python.md`](../litestar-styleguide/references/python.md) — Python conventions
-- [`../litestar-styleguide/references/litestar.md`](../litestar-styleguide/references/litestar.md) — Litestar-specific baseline
+- [`../../litestar-styleguide/references/general.md`](../../litestar-styleguide/references/general.md) — Cross-language baseline
+- [`../../litestar-styleguide/references/python.md`](../../litestar-styleguide/references/python.md) — Python conventions
+- [`../../litestar-styleguide/references/litestar.md`](../../litestar-styleguide/references/litestar.md) — Litestar-specific baseline

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "litestar-skills"
-version = "0.4.0"
+version = "0.5.0"
 description = "Opinionated first-party agent skills, plugins, subagents, slash commands, and MCP servers for the Litestar framework ecosystem"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -48,7 +48,8 @@ validation = [
   "flask>=3.0",        # advanced_alchemy.extensions.flask imports flask at module load
   "litestar[jinja,jwt]>=2.23",  # skill samples use 2.22/2.23 markers (FromQuery/JSONBody/NamedDependency/SkipValidation), litestar.plugins.jinja, and litestar.security.jwt
   "litestar-granian>=0.10",
-  "litestar-mcp>=0.7",  # litestar-mcp skill samples import LitestarMCP/MCPConfig/MCPAuthBackend/OIDCProviderConfig/mcp_prompt
+  "litestar-mcp>=0.9",  # litestar-mcp skill samples import LitestarMCP/MCP/MCPConfig/MCPAuthBackend/OIDCProviderConfig/mcp_prompt
+  "litestar-queues>=0.1",
   "litestar-saq>=0.5",
   "sanic[ext]>=24.6",  # advanced_alchemy.extensions.sanic imports sanic_ext at module load
   "sqlspec[adk,asyncpg,performance,psycopg]>=0.13",
@@ -154,7 +155,7 @@ exclude_lines = [
 # bump-my-version — atomic multi-manifest version sync
 # ============================================================
 [tool.bumpversion]
-current_version = "0.4.0"
+current_version = "0.5.0"
 commit = false
 tag = false
 tag_name = "v{new_version}"

--- a/skills/advanced-alchemy/SKILL.md
+++ b/skills/advanced-alchemy/SKILL.md
@@ -27,7 +27,7 @@ Advanced Alchemy is NOT a raw ORM — it is a **service/repository layer** built
 - **Repository pattern** for type-safe async CRUD
 - **Service layer** with lifecycle hooks (`to_model_on_create`, `to_model_on_update`)
 - **Framework plugins** for automatic session/transaction management
-- **Custom types**: `EncryptedString`, `FileObject`, `DateTimeUTC`, `GUID`
+- **Custom types**: `EncryptedString`, `FileObject`, `DateTimeUTC`, `GUID`, `Bool`, `Vector`, `TOTPSecret`, `OneTimeCode`
 - **Alembic integration** for migrations via CLI
 
 ## Quick Reference
@@ -69,13 +69,16 @@ Key lifecycle hooks: `to_model_on_create`, `to_model_on_update`, `to_model_on_up
 | `EncryptedString` | Transparent AES encryption at rest | Requires `ENCRYPTION_KEY` in config |
 | `UUID6` / `UUID7` | Time-sortable UUID variants | UUID7 preferred — monotonic ordering with millisecond timestamp prefix |
 | `DateTimeUTC` | Timezone-aware UTC datetime | Stores as UTC; raises on naive datetimes |
+| `Bool` | Dialect-aware boolean | Uses Oracle 23c native `BOOLEAN` when SQLAlchemy exposes it; falls back to stock SQLAlchemy `Boolean` |
+| `Vector` | Dialect-aware vector storage and distance operators | Oracle 23ai `VECTOR`, PostgreSQL/CockroachDB `pgvector`, JSON fallback without distance operators |
+| `TOTPSecret` / `OneTimeCode` | MFA and single-use code storage | `TOTPSecret` encrypts shared secrets; `OneTimeCode` hashes codes and requires an explicit hashing backend |
 
 ## Repository Service Layer
 
 `SQLAlchemyAsyncRepositoryService` is the primary service base class. Key behaviors:
 
 - **Dict-to-model conversion**: pass raw `dict` to `create()`, `update()`, `upsert()` — the service converts via `to_model_on_create` / `to_model_on_update` lifecycle hooks before persistence
-- **Bulk operations**: `create_many(data)`, `update_many(data)`, `upsert_many(data)`, `delete_many(item_ids)` — batched in a single transaction; prefer over calling single-row methods in a loop
+- **Bulk operations**: `create_many(data)`, `update_many(data)`, `upsert_many(data)`, `delete_many(item_ids)` — batched in a single transaction; `delete_many()` accepts raw primary keys, composite-key tuples/dicts, model instances, or mixed lists
 - **Lifecycle hooks**: `to_model_on_create`, `to_model_on_update`, `to_model_on_upsert` — override to transform input data, hash passwords, normalize strings, etc.
 
 ## Mixins
@@ -139,7 +142,7 @@ Run `alembic revision --autogenerate -m "description"` to create the migration, 
 - **Repositories are for data access only** — no business rules, no side effects beyond database operations
 - **Never bypass the service layer** to call repository methods directly from handlers
 - **Always set `match_fields`** on services that use `upsert()` to avoid duplicate-key errors
-- **Use `schema_dump()` to convert DTOs** (Pydantic/msgspec/attrs) before passing to service methods
+- **Use `schema_dump()` / `schema_dump_config` for explicit dump behavior** — services already convert Pydantic/msgspec/attrs/dataclass inputs during model conversion
 - **Prefer `UUIDAuditBase`** as default base class — only deviate when you have a concrete reason
 - **Use `advanced_alchemy.*` imports** — the old `litestar.plugins.sqlalchemy` paths are deprecated
 - **Model modules avoid `from __future__ import annotations`** — SQLAlchemy 2.0 needs the real `Mapped[...]` type at class-creation time. Consumer modules (handlers, services, tests) MAY use it.

--- a/skills/advanced-alchemy/references/fastapi-integration.md
+++ b/skills/advanced-alchemy/references/fastapi-integration.md
@@ -1,6 +1,6 @@
 # FastAPI integration
 
-This guide covers wiring Advanced Alchemy into a FastAPI application: the `Depends`-based DI pattern, the `provide_service` and `provide_filters` helpers, and the `alchemy database` CLI shim that ships with the FastAPI extension. Routing note: this guide covers FastAPI. For plain Starlette without `Depends`, see [starlette-integration.md](starlette-integration.md). For Flask (WSGI), see [flask-integration.md](flask-integration.md). For Sanic, see [sanic-integration.md](sanic-integration.md).
+This guide covers wiring Advanced Alchemy into a FastAPI application: the `Depends`-based DI pattern, the `provide_service` and `provide_filters` helpers, and the `database` / `db` CLI shim that ships with the FastAPI extension. Routing note: this guide covers FastAPI. For plain Starlette without `Depends`, see [starlette-integration.md](starlette-integration.md). For Flask (WSGI), see [flask-integration.md](flask-integration.md). For Sanic, see [sanic-integration.md](sanic-integration.md).
 
 ## Install
 
@@ -8,7 +8,7 @@ This guide covers wiring Advanced Alchemy into a FastAPI application: the `Depen
 pip install 'advanced-alchemy[fastapi]'
 ```
 
-This pulls FastAPI, Starlette (FastAPI's ASGI substrate), and the core Advanced Alchemy library. The async SQLAlchemy driver (`asyncpg`, `aiosqlite`, `asyncmy`, etc.) is installed separately. If you want the `alchemy` CLI integrated with `fastapi dev` / `fastapi run`, also install `fastapi[standard]` so `fastapi_cli` is available.
+This pulls FastAPI, Starlette (FastAPI's ASGI substrate), and the core Advanced Alchemy library. The async SQLAlchemy driver (`asyncpg`, `aiosqlite`, `asyncmy`, etc.) is installed separately. If you want the database CLI integrated with `fastapi dev` / `fastapi run`, also install `fastapi[standard]` so `fastapi_cli` is available.
 
 ## Entry point
 
@@ -238,7 +238,7 @@ The FastAPI extension ships a Click command group that wraps the Alembic CLI. Tw
 
 ### Via the FastAPI CLI (`fastapi dev` / `fastapi run`)
 
-If you have `fastapi_cli` installed (through the `fastapi[standard]` extra), call `assign_cli_group(app)` from your app module. This adds an `alchemy database` subcommand to the `fastapi` CLI:
+If you have `fastapi_cli` installed (through the `fastapi[standard]` extra), call `assign_cli_group(app)` from your app module. This registers Typer-native `database` and `db` commands on the FastAPI CLI and forwards to the Advanced Alchemy Click migration group. Use this Typer 0.26-compatible path; do not attach the Click group directly to Typer.
 
 ```python
 from advanced_alchemy.extensions.fastapi import AdvancedAlchemy, assign_cli_group
@@ -257,18 +257,19 @@ fastapi dev app.py database revision --autogenerate -m "add orders table"
 
 ### As a standalone Click entry point
 
-Alternatively, wire the command group into your own `__main__` using `register_database_commands(app)`:
+Alternatively, wire the command group into your own Click `__main__` using `register_database_commands(app)`:
 
 ```python
 if __name__ == "__main__":
-    from fastapi_cli.cli import app as fastapi_cli_app
-    from typer.main import get_group
-
     from advanced_alchemy.extensions.fastapi.cli import register_database_commands
+    from advanced_alchemy.utils.cli_tools import click
 
-    click_app = get_group(fastapi_cli_app)
-    click_app.add_command(register_database_commands(app))
-    click_app()
+    @click.group()
+    def cli() -> None:
+        """Application CLI."""
+
+    cli.add_command(register_database_commands(app))
+    cli()
 ```
 
 Then `python app.py database upgrade head` works without FastAPI's own CLI entry point.
@@ -401,5 +402,5 @@ One POST to `/orders` with `{"customer_email": "a@b.co", "total_cents": 9900}`:
 - [sanic-integration.md](sanic-integration.md) — `request.ctx`-based equivalent.
 - [services.md](services.md) — `SQLAlchemyAsyncRepositoryService` API.
 - [filters.md](filters.md) — the underlying filter types (`LimitOffset`, `SearchFilter`, etc.) that `provide_filters` assembles.
-- [migrations.md](migrations.md) — Alembic workflow behind `alchemy database`.
+- [migrations.md](migrations.md) — Alembic workflow behind the database CLI.
 - [../../litestar-styleguide/references/canonical-apps.md](../../litestar-styleguide/references/canonical-apps.md) — public reference apps (Litestar-based; service/repository code transfers directly).

--- a/skills/advanced-alchemy/references/services.md
+++ b/skills/advanced-alchemy/references/services.md
@@ -67,11 +67,14 @@ class UserService(SQLAlchemyAsyncRepositoryService[m.User]):
 ## Helper Utilities
 
 ```python
-from advanced_alchemy.service import schema_dump, is_dict_with_field, is_dict_without_field
+from advanced_alchemy.service import SchemaDumpConfig, schema_dump, is_dict_with_field, is_dict_without_field
 
 
 # Convert a Pydantic/msgspec/attrs schema to dict for service ingestion
 data = schema_dump(create_schema)
+
+# Tune dump behavior for partial updates or plain-object DTOs
+data = schema_dump(create_schema, config=SchemaDumpConfig(exclude_none=True))
 
 # Check dict shape before transforming
 if is_dict_with_field(data, "password"):
@@ -79,6 +82,27 @@ if is_dict_with_field(data, "password"):
 
 if is_dict_without_field(data, "slug"):
     data["slug"] = slugify(data["title"])
+```
+
+Set `schema_dump_config` on a service class to change the default conversion behavior for schema-like inputs. Pass `schema_dump_config=` to `create()`, `create_many()`, `update()`, `update_many()`, `upsert()`, `upsert_many()`, `get_or_upsert()`, or `get_and_update()` for a single operation.
+
+```python
+from advanced_alchemy.service import SchemaDumpConfig
+
+
+class UserService(SQLAlchemyAsyncRepositoryService[m.User]):
+    class Repo(SQLAlchemyAsyncRepository[m.User]):
+        model_type = m.User
+
+    repository_type = Repo
+    schema_dump_config = SchemaDumpConfig(exclude_unset=True, exclude_none=True)
+
+
+user = await service.update(
+    data=patch_schema,
+    item_id=user_id,
+    schema_dump_config=SchemaDumpConfig(exclude_none=True, exclude_defaults=True),
+)
 ```
 
 ## Common Service Operations
@@ -110,6 +134,7 @@ user = await service.upsert({"email": "test@example.com", "name": "Test"})
 
 # Delete
 await service.delete(user_id)
+await service.delete_many([user_id, user_model])  # raw IDs, model instances, and mixed lists are valid
 
 # Exists / Count
 exists = await service.exists(email="test@example.com")

--- a/skills/advanced-alchemy/references/types.md
+++ b/skills/advanced-alchemy/references/types.md
@@ -14,6 +14,10 @@ from advanced_alchemy.types import (
     BigIntIdentity,
     ORA_JSONB,
     PasswordHash,
+    Bool,
+    Vector,
+    TOTPSecret,
+    OneTimeCode,
 )
 from advanced_alchemy.types.file_object import FileObject, StoredObject
 ```
@@ -60,7 +64,7 @@ class Token(UUIDAuditBase):
 
 ## JsonB
 
-Cross-database JSONB type. Uses native `JSONB` on PostgreSQL (with indexing support). Falls back to standard `JSON` on other databases.
+Cross-database JSONB type. Uses native `JSONB` on PostgreSQL/CockroachDB (with indexing support). On Oracle, it routes through `ORA_JSONB`; other databases use standard `JSON`.
 
 ```python
 from advanced_alchemy.types import JsonB
@@ -72,14 +76,15 @@ class Config(UUIDAuditBase):
     tags: Mapped[list] = mapped_column(JsonB, default=list)
 ```
 
-- On PostgreSQL, supports GIN indexing for fast key/value lookups
-- On SQLite/MySQL, stores as JSON text
+- On PostgreSQL/CockroachDB, supports native JSONB indexing for fast key/value lookups.
+- On Oracle with SQLAlchemy 2.1+ and Oracle 21c+, stores as native `oracle.JSON`; otherwise uses BLOB binary JSON with an `IS JSON` check constraint.
+- On SQLite/MySQL, stores as standard `JSON`.
 
 ---
 
 ## ORA_JSONB
 
-Oracle-compatible JSONB type. Handles Oracle's specific JSON column semantics while remaining compatible with other databases.
+Oracle-compatible JSONB type. Uses native `sqlalchemy.dialects.oracle.JSON` on SQLAlchemy 2.1+ when the Oracle server is 21c or newer. Falls back to BLOB binary JSON with an `IS JSON` check constraint when native Oracle JSON is unavailable.
 
 ```python
 from advanced_alchemy.types import ORA_JSONB
@@ -90,8 +95,8 @@ class OracleModel(UUIDAuditBase):
     metadata_: Mapped[dict] = mapped_column(ORA_JSONB, default=dict)
 ```
 
-- Use when targeting Oracle as a primary or secondary database
-- Falls back to standard JSON behavior on non-Oracle backends
+- Use when targeting Oracle as a primary or secondary database.
+- Keep the fallback path in mind for SQLAlchemy 2.0.x, Oracle 19c, offline DDL, or first-connect flows without server version information.
 
 ---
 
@@ -307,7 +312,7 @@ if document.file:
 
 ## Bool (dialect-aware boolean)
 
-`Bool` (added 1.11) resolves to each dialect's native boolean, including Oracle 23c's real `BOOLEAN` (falling back to `NUMBER(1)` on older Oracle). Use it instead of `sqlalchemy.Boolean` when the model must run on Oracle as well as PostgreSQL/SQLite/MySQL.
+`Bool` (added 1.11) resolves to each dialect's stock boolean type, including Oracle 23c's real `BOOLEAN` when SQLAlchemy exposes `oracle.BOOLEAN`. Older Oracle versions and SQLAlchemy 2.0.x fall back to stock SQLAlchemy `Boolean`. Use it when a model must run on Oracle as well as PostgreSQL/SQLite/MySQL.
 
 ```python
 from advanced_alchemy.types import Bool
@@ -345,22 +350,28 @@ stmt = (
 
 ## TOTP and One-Time Codes
 
-Added in 1.11 for authentication flows. `TOTPSecret` is an `EncryptedString` subtype that stores a TOTP shared secret encrypted at rest; pair it with `TOTPProvider` / `generate_totp_secret` to issue and verify codes. `OneTimeCode` is the SQLAlchemy column type for single-use codes (email/SMS verification); loaded values expose the `HashedOneTimeCode` verification wrapper.
+Added in 1.11 for authentication flows. `TOTPSecret` is an `EncryptedString` subtype that stores a TOTP shared secret encrypted at rest; it requires `pyotp` and an explicit encryption key. Pair it with `TOTPProvider` / `generate_totp_secret` to issue and verify codes. `OneTimeCode` is the SQLAlchemy column type for single-use codes (email/SMS verification); it requires an explicit password-hashing backend and loaded values expose the `HashedOneTimeCode` verification wrapper.
 
 ```python
+from typing import Any
+
 from advanced_alchemy.types import (
     TOTPSecret,
     OneTimeCode,
     generate_totp_secret,
     generate_one_time_code,
 )
+from advanced_alchemy.types.password_hash.argon2 import Argon2Hasher
 from sqlalchemy.orm import Mapped, mapped_column
 
 
 class Account(UUIDBase):
     totp_secret: Mapped[str | None] = mapped_column(TOTPSecret(key=ENCRYPTION_KEY), default=None)
     # writes a plaintext code; the column hashes it. Loaded values verify through HashedOneTimeCode.
-    email_code: Mapped[str | None] = mapped_column(OneTimeCode, default=None)
+    email_code: Mapped[Any | None] = mapped_column(
+        OneTimeCode(backend=Argon2Hasher(), ttl_seconds=600, max_attempts=3),
+        default=None,
+    )
 ```
 
 ## Type Compatibility Matrix
@@ -369,12 +380,12 @@ class Account(UUIDBase):
 | --- | --- | --- | --- | --- |
 | `DateTimeUTC` | `TIMESTAMP WITH TIME ZONE` | `DATETIME` | `DATETIME` | `TIMESTAMP WITH TIME ZONE` |
 | `GUID` | `UUID` (native) | `CHAR(32)` / `BINARY(16)` | `CHAR(32)` / `BINARY(16)` | `RAW(16)` |
-| `JsonB` | `JSONB` (native) | `JSON` | `JSON` | `JSON` |
-| `ORA_JSONB` | `JSONB` | `JSON` | `JSON` | `JSON` (Oracle-optimized) |
+| `JsonB` | `JSONB` (native) | `JSON` | `JSON` | `oracle.JSON` on SQLAlchemy 2.1+ / Oracle 21c+; BLOB + check constraint fallback |
+| `ORA_JSONB` | `JSONB` | `JSON` | `JSON` | `oracle.JSON` on SQLAlchemy 2.1+ / Oracle 21c+; BLOB + check constraint fallback |
 | `BigIntIdentity` | `BIGSERIAL` | `INTEGER` | `BIGINT AUTO_INCREMENT` | `NUMBER(19)` |
 | `EncryptedString` | `VARCHAR` | `VARCHAR` | `VARCHAR` | `VARCHAR2` |
 | `EncryptedText` | `TEXT` | `TEXT` | `TEXT` | `CLOB` |
 | `PasswordHash` | `VARCHAR` | `VARCHAR` | `VARCHAR` | `VARCHAR2` |
 | `StoredObject` | `JSONB` | `JSON` | `JSON` | `JSON` |
-| `Bool` | `BOOLEAN` | `BOOLEAN` | `BOOL` | `BOOLEAN` (23c) / `NUMBER(1)` |
-| `Vector` | `pgvector` / JSON | `JSON` | `JSON` | `VECTOR` (23ai) / JSON |
+| `Bool` | `BOOLEAN` | `BOOLEAN` | `BOOL` | `BOOLEAN` on SQLAlchemy 2.1+ / Oracle 23c+; stock SQLAlchemy `Boolean` fallback |
+| `Vector` | `pgvector` / JSON | `JSON` | `JSON` | `VECTOR` |

--- a/skills/litestar-mcp/SKILL.md
+++ b/skills/litestar-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: litestar-mcp
-description: "Auto-activate for litestar_mcp, LitestarMCP, MCPConfig, MCPAuthConfig, MCPAuthBackend, mcp_tool=, mcp_resource=, Streamable HTTP, or OIDC MCP endpoints. Not for non-Litestar MCP."
+description: "Auto-activate for litestar_mcp, LitestarMCP, MCP, MCPConfig, mcp.app, mcp.run(), @mcp.tool/resource/prompt, MCPAuthConfig, MCPAuthBackend, mcp_tool=, mcp_resource=, Streamable HTTP, stdio, or OIDC MCP endpoints. Not for non-Litestar MCP."
 ---
 
 # litestar-mcp
@@ -13,7 +13,7 @@ Mark routes by passing `mcp_tool="name"`, `mcp_resource="name"`, or `mcp_prompt=
 
 - PEP 604 unions: `T | None`, never `Optional[T]`
 - Consumer Litestar app modules MAY use `from __future__ import annotations`
-- Async all I/O - handlers exposed through MCP must be `async def`
+- Async all I/O. Pure standalone `@mcp.tool` / `@mcp.resource` / `@mcp.prompt` functions may be sync; keep blocking I/O out of the event loop.
 
 ## Quick Reference
 
@@ -71,6 +71,7 @@ The default MCP surface is:
 | `base_path` | `str` | `"/mcp"` | URL prefix for the MCP Streamable HTTP endpoint |
 | `include_in_schema` | `bool` | `False` | Include MCP routes in OpenAPI |
 | `name` | `str \| None` | `None` | Server name; defaults to OpenAPI title |
+| `instructions` | `str \| None` | `None` | Server instructions advertised to MCP clients |
 | `guards` | `list[Any] \| None` | `None` | Litestar guards applied to the MCP router |
 | `allowed_origins` | `list[str] \| None` | `None` | Restrict accepted `Origin` headers |
 | `include_operations` | `list[str] \| None` | `None` | Only expose matching operation names |
@@ -80,6 +81,8 @@ The default MCP surface is:
 | `auth` | `MCPAuthConfig \| None` | `None` | OAuth protected-resource metadata |
 | `tasks` | `bool \| MCPTaskConfig` | `False` | Enable experimental in-memory MCP task support |
 | `list_page_size` | `int` | `100` | Page size for `tools/list`, `resources/list`, `resources/templates/list`, `prompts/list` (clients page via opaque cursors) |
+| `before_tool_call` | `BeforeToolCallHook \| None` | `None` | Observe each `tools/call` before dispatch |
+| `after_tool_call` | `AfterToolCallHook \| None` | `None` | Observe each `tools/call` result, exception, and duration |
 | `opt_keys` | `MCPOptKeys` | `MCPOptKeys()` | Rename the `handler.opt` keys the plugin reads (e.g. to avoid collisions) |
 | `session_store` | `Store \| None` | `None` | Litestar `Store` backing MCP sessions; defaults to an in-memory store |
 | `session_max_idle_seconds` | `float` | `3600.0` | Idle timeout before an MCP session is evicted |
@@ -145,6 +148,45 @@ Use structured metadata when the agent needs sharper tool selection:
 async def generate_report(data: ReportRequest) -> ReportQueued: ...
 ```
 
+### Standalone MCP App
+
+Use `MCP(...)` when the application is primarily an MCP server. Use `LitestarMCP(...)` when adding MCP to an existing Litestar app.
+
+```python
+from litestar_mcp import MCP
+
+
+mcp = MCP("inventory-mcp", instructions="Expose inventory tools.")
+
+
+@mcp.tool(name="lookup_product", description="Look up a product by SKU.")
+def lookup_product(sku: str) -> dict[str, str]:
+    return {"sku": sku, "status": "active"}
+
+
+@mcp.resource(uri="inventory://status", name="inventory_status")
+def inventory_status() -> dict[str, str]:
+    return {"status": "healthy"}
+
+
+@mcp.prompt(name="summarize_product")
+def summarize_product(sku: str) -> str:
+    return f"Summarize product {sku}."
+
+
+app = mcp.app
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")
+```
+
+`mcp.app` lazily builds the underlying `Litestar` instance; access it after registering standalone decorators. `@mcp.tool`, `@mcp.resource`, and `@mcp.prompt` accept normal Litestar route-handler kwargs such as `dependencies`, `guards`, `tags`, DTO options, hooks, and `sync_to_thread`. The `name` kwarg names the MCP primitive; use `route_name` when the Litestar route handler itself needs a name.
+
+`MCP(...)` also accepts `config=`, existing `plugins=`, existing `route_handlers=`, and standard `Litestar(...)` app kwargs. Use that pass-through when a standalone MCP app still needs Litestar middleware, dependencies, CORS, or additional non-MCP routes.
+
+`mcp.run(transport="sse", port=8000)` starts the HTTP/SSE transport through the Litestar CLI, so expose `app = mcp.app` at module scope or set `LITESTAR_APP` for worker/reload discovery. `mcp.run(transport="stdio")` reads line-delimited JSON-RPC from stdin, writes responses to stdout, manually drives ASGI lifespan, and dispatches through the same JSON-RPC router with a synthetic request context.
+
 ### Hiding Routes
 
 Discovery is opt-in: a handler that carries no `mcp_*` marker never appears in MCP. There is no per-route exclude flag — `opt={"mcp_exclude": True}` is ignored.
@@ -169,6 +211,24 @@ To drop *marked* routes in bulk, use the `MCPConfig` filters (`exclude_tags` / `
   }
 }
 ```
+
+Direct router use is transport-internal. Current `JSONRPCRouter.dispatch()` takes a parsed request plus `RequestContext`; HTTP builds that context from the live `Request`, while stdio uses `client_id="stdio"`, `owner_id="stdio"`, and `request=None`. Do not import `litestar_mcp.routes.build_jsonrpc_router`; use `LitestarMCP` or `MCP` unless you are maintaining `litestar-mcp` transport internals.
+
+### Pagination, Signatures, And Errors
+
+`tools/list`, `resources/list`, `resources/templates/list`, and `prompts/list` use opaque cursor pagination. Clients pass `params.cursor` from `nextCursor` until the response omits it; clients do not send `limit`. Set server page size with `MCPConfig(list_page_size=...)`; invalid cursors return `INVALID_PARAMS` (`-32602`).
+
+Tool arguments are validated against Litestar's `handler.parsed_fn_signature` before dispatch. Do not reference legacy `signature_model` or private validation-context parameter lists.
+
+Tool execution errors stay inside the tool result with `isError: true`; protocol errors such as unknown tool names use JSON-RPC errors. Resource and prompt handler failures use primitive-level JSON-RPC codes and preserve the handler HTTP status in `error.data.statusCode` when a handler response produced one. Do not invent status-code-specific JSON-RPC codes for 401/403/409/429.
+
+### Tool-Call Callbacks
+
+Use `MCPConfig.before_tool_call` and `MCPConfig.after_tool_call` for audit, metrics, or tracing that must fire around `tools/call` regardless of route ownership. Both callbacks receive the MCP tool name, a shallow copy of submitted arguments, and the synthesized `Request`. `after_tool_call` also receives keyword-only `result`, `exception`, and `duration`; it fires for successes, guard failures, handled error responses, and unhandled exceptions. Callback exceptions are logged and swallowed.
+
+### Dependency Providers And Dishka
+
+Litestar `Provide(...)` factory parameters that are user inputs, such as pagination or filter values, remain in tool schemas and forward during `tools/call`. When `dishka.integrations.litestar.setup_dishka()` is attached, provider-factory parameters whose annotated type is resolvable from `app.state.dishka_container` are treated as DI inputs instead of MCP arguments. Dishka remains optional; installs without Dishka should still import and run `litestar_mcp`.
 
 ### Built-in OpenAPI Resource
 
@@ -240,7 +300,7 @@ List only the routes that should be callable by AI clients. Mark those routes wi
 
 ### Step 3: Add the Plugin
 
-Wire `LitestarMCP(MCPConfig(name=...))` into `Litestar(plugins=[...])`. Use `include_tags` or `include_operations` when you need a second allowlist.
+Wire `LitestarMCP(MCPConfig(name=...))` into `Litestar(plugins=[...])`, or use standalone `MCP(...)` when the app exists only to serve MCP primitives. Use `include_tags` or `include_operations` when you need a second allowlist.
 
 ### Step 4: Add Auth
 
@@ -248,7 +308,7 @@ For public endpoints, configure bearer-token validation and `MCPAuthConfig` meta
 
 ### Step 5: Verify
 
-Hit `POST /mcp` with `tools/list` and `resources/list`. Confirm only marked routes appear. Call one representative tool and read one representative resource.
+For Streamable HTTP, initialize first: `POST /mcp` with `initialize`, send `notifications/initialized`, then include the returned `Mcp-Session-Id` header on later `tools/list`, `resources/list`, `tools/call`, and `resources/read` requests. Confirm only marked routes appear, call one representative tool, and read one representative resource. For standalone stdio apps, send one line-delimited JSON-RPC request through stdin and confirm the response is written to stdout.
 
 </workflow>
 
@@ -263,6 +323,8 @@ Hit `POST /mcp` with `tools/list` and `resources/list`. Confirm only marked rout
 - **Keep DTOs precise** - loose `dict[str, Any]` request schemas produce weak tool contracts.
 - **Use `MCPAuthConfig` plus token validation for public MCP** - metadata alone does not authenticate requests.
 - **Set `allowed_origins` for browser-accessible MCP clients** - leave it `None` only for trusted server-to-server deployments.
+- **Treat `MCP` and `LitestarMCP` as public entry points** - avoid private router/service imports unless you are maintaining `litestar-mcp` transport internals.
+- **Keep observability callbacks side-effect safe** - `before_tool_call` / `after_tool_call` failures are swallowed, so callbacks must not enforce authorization or business invariants.
 
 </guardrails>
 
@@ -272,15 +334,17 @@ Hit `POST /mcp` with `tools/list` and `resources/list`. Confirm only marked rout
 
 Before delivering an MCP integration, verify:
 
-- [ ] `LitestarMCP` is in `app.plugins`
-- [ ] Exposed routes use `mcp_tool=`, `mcp_resource=`, or `mcp_resource_template=`
+- [ ] Existing Litestar apps include `LitestarMCP` in `app.plugins`; standalone apps expose `app = mcp.app`
+- [ ] Exposed routes/functions use `mcp_tool=`, `mcp_resource=`, `mcp_prompt=`, `@mcp.tool`, `@mcp.resource`, or `@mcp.prompt`
 - [ ] Admin / internal routes are left unmarked, or kept outside `include_*` / inside `exclude_*` — with `guards` or auth enforcing access
 - [ ] Auth is configured for the deployment boundary
 - [ ] `POST /mcp` `tools/list` returns only intended tools
 - [ ] `POST /mcp` `resources/list` includes only intended resources plus `litestar://openapi`
 - [ ] Filtered tools/resources/templates fail direct invocation as unknown
-- [ ] Provider-declared query parameters appear in tool `inputSchema` and forward during `tools/call`
-- [ ] Exposed handlers are `async def` and return JSON-serializable types
+- [ ] Provider-declared user inputs appear in tool `inputSchema`; Dishka-resolved service parameters do not
+- [ ] `before_tool_call` / `after_tool_call` callbacks are covered when configured, including failure paths
+- [ ] Standalone `MCP` SSE or stdio transport is smoke-tested for the chosen deployment mode
+- [ ] Exposed handlers performing I/O are `async def`; sync standalone functions are pure/non-blocking and return JSON-serializable types
 - [ ] Tool argument DTOs are specific enough for generated schemas
 
 </validation>

--- a/skills/litestar-queues/SKILL.md
+++ b/skills/litestar-queues/SKILL.md
@@ -1,0 +1,476 @@
+---
+name: litestar-queues
+description: "Auto-activate for litestar_queues, QueuePlugin, QueueConfig, QueueService, @task, QueuedBackgroundTask, TaskResult, litestar queues run/status/scheduler-health, queue backends, execution backends, schedules, or task progress events. Not for litestar-saq/SAQ, Celery, RQ, or Dramatiq — those use different APIs and worker lifecycles."
+---
+
+# litestar-queues
+
+`litestar-queues` is the first-party Litestar worker abstraction for task registration, queue persistence, worker lifecycle, schedules, and application-facing queue events.
+
+Use it when a Litestar app needs its own queue layer with explicit queue backend selection, local or Cloud Run execution, `QueueService` DI, and task progress events. Keep queue storage and execution separate:
+
+- **Queue backend** stores task records and state.
+- **Execution backend** decides where claimed work runs.
+
+## Code Style Rules
+
+- Use PEP 604 unions: `T | None`, never `Optional[T]`.
+- Use `async def` for route handlers, dependency resolvers, task I/O, and event publishing.
+- Inject `QueueService` with `NamedDependency[QueueService]`; do not import a module-level queue service in handlers.
+- Import core APIs from `litestar_queues`. Import optional backend config classes from their documented backend submodules.
+- Keep task payloads JSON-serializable when using Redis, Valkey, SQLSpec, Advanced Alchemy, or Cloud Run backends.
+- Prefer `msgspec` for event/client DTOs in Litestar apps unless the project already standardizes on Pydantic.
+
+## Quick Reference
+
+### Minimal Plugin Setup
+
+```python
+from litestar import Litestar, post
+from litestar.di import NamedDependency
+from litestar_queues import QueueConfig, QueuePlugin, QueueService, task
+
+
+@task("accounts.sync", queue="accounts", retries=3, timeout=300)
+async def sync_account(account_id: str) -> dict[str, str]:
+    return {"account_id": account_id, "status": "synced"}
+
+
+@post("/accounts/{account_id:str}/sync")
+async def create_sync_job(
+    account_id: str,
+    queue_service: NamedDependency[QueueService],
+) -> dict[str, str]:
+    result = await queue_service.enqueue(sync_account, account_id)
+    return {"task_id": str(result.id), "status": result.status or "queued"}
+
+
+app = Litestar(
+    route_handlers=[create_sync_job],
+    plugins=[QueuePlugin(config=QueueConfig())],
+)
+```
+
+### Task Registration and Enqueueing
+
+```python
+from datetime import timedelta
+
+from litestar_queues import QueueService, task
+
+
+@task(
+    "reports.render",
+    queue="reports",
+    priority=10,
+    retries=2,
+    timeout=120,
+    run_after=30,
+)
+async def render_report(report_id: str) -> str:
+    return report_id
+
+
+async def queue_report(queue_service: QueueService, report_id: str) -> str:
+    result = await queue_service.enqueue(
+        render_report,
+        report_id,
+        key=f"report:{report_id}",
+        timeout=600,
+        metadata={"requested_by": "system"},
+    )
+    await result.wait(timeout=30)
+    return result.status or "unknown"
+
+
+@task("reports.refresh", interval=timedelta(minutes=15), jitter=30)
+async def refresh_reports() -> None:
+    ...
+
+
+@task("billing.close-day", cron="0 0 * * *", timezone="UTC")
+async def close_billing_day() -> None:
+    ...
+```
+
+`QueueService.enqueue()` accepts a decorated `Task` object or registered task name. Use `task_modules=("app.tasks",)` or `discover_tasks("app.domain")` so string-enqueued tasks and schedules are imported during startup.
+
+`TaskResult` is a handle over the queued record. Use `await result.refresh()` to reload state and `await result.wait(timeout=30)` to poll until `completed`, `failed`, or `cancelled`.
+
+### Background Responses
+
+```python
+from litestar import Response, post
+from litestar_queues import QueuedBackgroundTask, task
+
+
+@task("imports.process")
+async def process_import(path: str) -> None:
+    ...
+
+
+@post("/imports")
+async def create_import() -> Response[dict[str, str]]:
+    return Response(
+        {"status": "queued"},
+        background=QueuedBackgroundTask(process_import, "/tmp/data.csv"),
+    )
+```
+
+Use `QueuedBackgroundTask` when a response should be sent before enqueueing. It resolves the active `QueueService` from `QueuePlugin`; pass `service=queue_service` when using a custom service.
+
+### Worker Placement
+
+```python
+# Local development, tests, and lightweight deployments.
+queue_config = QueueConfig(in_app_worker=True)
+
+# Production sidecar/worker service.
+queue_config = QueueConfig(in_app_worker=False)
+```
+
+```bash
+LITESTAR_APP=app:app litestar queues run --drain-timeout 30
+LITESTAR_APP=app:app litestar queues run --queue accounts --max-concurrency 4
+LITESTAR_APP=app:app litestar queues status --json
+LITESTAR_APP=app:app litestar queues scheduler-health --minutes 5
+```
+
+In-app workers share the web process and are the default. Standalone workers load the same Litestar app, open the plugin service, and process all queues unless `--queue` is repeated.
+
+### Backend and Execution Selection
+
+| Need | Queue backend | Execution backend | Install / import |
+| --- | --- | --- | --- |
+| Unit tests, examples, one-process local apps | `queue_backend="memory"` | `"local"` or `"immediate"` | Core package |
+| SQLSpec-first app or SQL-backed persistence without SQLAlchemy ORM | `SQLSpecBackendConfig(...)` | `"local"` | `litestar-queues[sqlspec]`; `from litestar_queues.backends.sqlspec import SQLSpecBackendConfig` |
+| Advanced Alchemy / SQLAlchemy app with Alembic-owned models | `AdvancedAlchemyBackendConfig(...)` | `"local"` | `litestar-queues[advanced-alchemy]`; `from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyBackendConfig` |
+| Redis already in the stack for cache, pub/sub, or shared infra | `RedisBackendConfig(...)` | `"local"` | `litestar-queues[redis]`; `from litestar_queues.backends.redis import RedisBackendConfig` |
+| Valkey is the chosen Redis-compatible service | `ValkeyBackendConfig(...)` | `"local"` | `litestar-queues[valkey]`; `from litestar_queues.backends.valkey import ValkeyBackendConfig` |
+| Inline test/script execution with completed results immediately | Any backend | `"immediate"` | Core package |
+| Heavy or isolated jobs on Google Cloud Run Jobs | Persistent queue backend | `CloudRunExecutionConfig(...)` | `litestar-queues[cloudrun]`; `from litestar_queues.execution.cloudrun import CloudRunExecutionConfig` |
+
+Pick the backend that matches the project:
+
+- Use `memory` only for same-process work; it does not coordinate separate worker processes.
+- Use `SQLSpecBackendConfig` when the app already uses SQLSpec or wants adapter-level SQL persistence.
+- Use `AdvancedAlchemyBackendConfig` when the app already uses Advanced Alchemy / SQLAlchemy models and migrations; import the queue model into Alembic when the app owns schema.
+- Use `RedisBackendConfig` or `ValkeyBackendConfig` when that service already exists and task payloads can stay JSON-serializable.
+- Use `CloudRunExecutionConfig` only for execution; keep queue persistence on memory only for local experiments and on a shared persistent backend for real deployments.
+
+### SQLSpec Queue Backend
+
+```python
+from sqlspec.adapters.aiosqlite import AiosqliteConfig
+
+from litestar_queues import QueueConfig
+from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
+
+
+queue_config = QueueConfig(
+    queue_backend=SQLSpecBackendConfig(
+        config=AiosqliteConfig(connection_config={"database": "queue.db"}),
+        create_schema=False,
+        run_migrations=True,
+    ),
+    execution_backend="local",
+    in_app_worker=False,
+)
+```
+
+### Advanced Alchemy Queue Backend
+
+```python
+from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig
+from litestar_queues import QueueConfig
+from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyBackendConfig
+
+
+alchemy_config = SQLAlchemyAsyncConfig(connection_string="sqlite+aiosqlite:///queue.db")
+
+queue_config = QueueConfig(
+    queue_backend=AdvancedAlchemyBackendConfig(
+        sqlalchemy_config=alchemy_config,
+        create_schema=False,
+    ),
+    execution_backend="local",
+)
+```
+
+Set `create_schema=True` only for local bootstrap or tests. Production apps that manage schema with Alembic should import the queue model into the Alembic environment. Use `QueueTaskModelMixin` plus `model_class=` when the app needs its own table name, base class, bind metadata, or migration ownership.
+
+### Redis or Valkey Queue Backend
+
+```python
+from litestar_queues import QueueConfig
+from litestar_queues.backends.redis import RedisBackendConfig
+
+
+queue_config = QueueConfig(
+    queue_backend=RedisBackendConfig(
+        url="redis://localhost:6379/0",
+        key_prefix="litestar_queues",
+        notifications=True,
+    ),
+    execution_backend="local",
+)
+```
+
+Swap `RedisBackendConfig` for `ValkeyBackendConfig` from `litestar_queues.backends.valkey` when the project uses Valkey.
+
+### Cloud Run Execution
+
+```python
+from litestar_queues import QueueConfig, task
+from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
+from litestar_queues.execution.cloudrun import CloudRunExecutionConfig
+
+
+@task("reports.render", execution_backend="cloudrun", execution_profile="heavy")
+async def render_report(report_id: str) -> None:
+    ...
+
+
+queue_config = QueueConfig(
+    queue_backend=SQLSpecBackendConfig(config=...),
+    execution_backend=CloudRunExecutionConfig(
+        project_id="example-project",
+        region="us-central1",
+        job_name="queue-worker",
+        profiles={"heavy": "queue-worker-heavy"},
+        extra_env={
+            "LITESTAR_QUEUES_CONFIG_FACTORY": "app.queue:create_queue_config",
+            "LITESTAR_QUEUES_TASK_MODULES": "app.tasks",
+        },
+    ),
+)
+```
+
+Run the Cloud Run container with `litestar-queues-cloudrun-worker` or `python -m litestar_queues.execution.cloudrun.entrypoint`. The entrypoint reads `LITESTAR_QUEUES_TASK_ID`, loads `LITESTAR_QUEUES_CONFIG_FACTORY` and `LITESTAR_QUEUES_TASK_MODULES`, claims the persisted record, heartbeats, executes, and returns deterministic exit codes. The config factory must return the same `QueueConfig`, `QueueService`, or async context manager used by the dispatch worker; otherwise the entrypoint falls back to an isolated default `QueueConfig()`.
+
+### Events and Progress
+
+```python
+from litestar_queues import QueueConfig, task
+from litestar_queues.events import QueueEventConfig, publish_task_log, publish_task_progress
+
+
+queue_config = QueueConfig(
+    event_config=QueueEventConfig(
+        enabled=True,
+        channels_backend=channels,
+        publish_global_lifecycle=True,
+    ),
+)
+
+
+@task("imports.process")
+async def process_import(path: str) -> None:
+    await publish_task_log("Import started", payload={"path": path})
+    await publish_task_progress(current=5, total=10, message="Halfway done")
+```
+
+Queue events are application-facing envelopes. They are separate from queue backend wakeup notifications. Use `TaskExecutionContext` via `_task_context` when a task needs direct access to `progress()`, `log()`, or `event()`.
+
+### Dependency Resolver
+
+```python
+from typing import Any
+
+from litestar_queues import QueueConfig, QueuedTaskRecord, Task, TaskExecutionContext, task
+
+
+async def resolve_task_dependencies(
+    _task: Task[Any, Any],
+    _record: QueuedTaskRecord,
+    _context: TaskExecutionContext,
+) -> dict[str, Any]:
+    return {"settings": {"environment": "production"}}
+
+
+@task("reports.generate")
+async def generate_report(*, settings: dict[str, Any]) -> str:
+    return f"generated for {settings['environment']}"
+
+
+queue_config = QueueConfig(task_dependency_resolver=resolve_task_dependencies)
+```
+
+Resolvers run once per attempt after `task.started` and before the task body. Return kwargs that match task parameters. Resolver exceptions follow the normal retry/failure path.
+
+<workflow>
+
+## Workflow
+
+### Step 1: Identify the Work Shape
+
+Use `litestar-queues` when the app needs durable task state, scheduled jobs, progress events, or worker placement choices. Use `QueuedBackgroundTask` only when the Litestar response lifecycle is the trigger and the actual work should still go through the queue.
+
+### Step 2: Pick Queue Backend
+
+Match the project stack. Start with `memory` only for tests and local single-process apps. Use SQLSpec for SQLSpec apps, Advanced Alchemy for SQLAlchemy/Advanced Alchemy apps, Redis for Redis-backed infrastructure, and Valkey for Valkey infrastructure.
+
+### Step 3: Pick Execution Backend
+
+Use `local` for normal in-process worker execution. Use `immediate` for tests and scripts that need inline completion. Use `CloudRunExecutionConfig` when tasks must run in Google Cloud Run Jobs and the queue backend is shared across web, dispatch worker, and remote worker containers.
+
+### Step 4: Configure `QueuePlugin`
+
+Register `QueuePlugin(config=QueueConfig(...))` in `Litestar(plugins=[...])`. Set `task_modules` when tasks are not otherwise imported before startup. Keep `initialize_schedules=True` unless schedule sync is owned by a separate process.
+
+### Step 5: Define Tasks and Schedules
+
+Decorate callables with `@task("name", ...)`. Put defaults on the decorator (`queue`, `priority`, `retries`, `timeout`, `run_after`, `execution_backend`, `execution_profile`, `key`). Use `interval` or five-field `cron`, not both.
+
+### Step 6: Enqueue from Handlers or Services
+
+Inject `QueueService` with `NamedDependency[QueueService]`. Call `await queue_service.enqueue(task_or_name, *args, **kwargs)` and use `TaskResult.refresh()` or `TaskResult.wait()` only when the caller truly needs observed completion.
+
+### Step 7: Place Workers
+
+Keep `in_app_worker=True` for tests, local development, and lightweight apps. Set `in_app_worker=False` and run `litestar queues run` as a separate service when web and background capacity must scale independently.
+
+### Step 8: Add Events and Resolver Hooks
+
+Enable `QueueEventConfig` only when clients or operators consume lifecycle, progress, log, or custom events. Add `task_dependency_resolver` only when tasks need services from an external DI container.
+
+</workflow>
+
+<guardrails>
+
+## Guardrails
+
+- **Use `QueuePlugin` for Litestar apps** — it wires DI, app state, lifespan, task module imports, schedule initialization, worker startup, and CLI commands.
+- **Do not use `memory` for standalone production workers** — memory state is process-local and cannot coordinate web and worker processes.
+- **Do not mix queue backend and execution backend concerns** — Cloud Run is execution; Redis, Valkey, SQLSpec, Advanced Alchemy, and memory store queue state.
+- **Do not import optional backends from `litestar_queues.backends`** — import config classes from `litestar_queues.backends.sqlspec`, `.advanced_alchemy`, `.redis`, or `.valkey`.
+- **Set `task_modules` or call `discover_tasks()`** when enqueueing by string or relying on schedules; decorators register tasks only after modules import.
+- **Use `QueueService.enqueue()` in handlers and services** — reserve `Task.enqueue()` for code running under an active `QueuePlugin` default service or for intentional immediate fallback.
+- **Always set explicit `timeout` on real tasks** — long-running workers need predictable cancellation and failure behavior.
+- **Use `key=` for deduplication** when repeated requests target the same logical job.
+- **Treat backend wakeup notifications as hints** — workers still rely on polling and durable queue state.
+- **Keep dependency resolvers per-attempt clean** — return fresh request/session handles and let failures participate in normal task retry handling.
+- **Use `scheduler-health` only after registering a recurring canary task** matching `QueueConfig.scheduler_canary_task`.
+
+</guardrails>
+
+<validation>
+
+### Validation Checkpoint
+
+Before delivering Litestar Queues code, verify:
+
+- [ ] `QueuePlugin(config=QueueConfig(...))` is registered in `app.plugins`
+- [ ] `QueueConfig.queue_backend` matches the project's persistence stack
+- [ ] `QueueConfig.execution_backend` matches where tasks should run
+- [ ] `in_app_worker` is intentional for the deployment shape
+- [ ] Standalone deployments use a shared persistent queue backend
+- [ ] `task_modules` or `discover_tasks()` imports all decorated task modules
+- [ ] Handlers inject `NamedDependency[QueueService]`
+- [ ] Enqueue calls use `QueueService.enqueue()` with explicit `timeout`, `retries`, and `key` where needed
+- [ ] Scheduled tasks use either `interval` or five-field `cron`
+- [ ] `initialize_schedules` is enabled in exactly one startup path when multiple app processes exist
+- [ ] Event publishing is enabled only when a sink or Channels backend is configured
+- [ ] Dependency resolver output matches task keyword parameters
+- [ ] `litestar queues run/status/scheduler-health` commands load the intended Litestar app through `LITESTAR_APP` or `--app`
+
+</validation>
+
+<example>
+
+## Example
+
+**Task:** A Litestar app queues report jobs to SQLSpec, runs workers as a standalone service, publishes progress, and has a scheduler canary.
+
+```python
+from datetime import timedelta
+
+from litestar import Litestar, post
+from litestar.di import NamedDependency
+from sqlspec.adapters.aiosqlite import AiosqliteConfig
+
+from litestar_queues import QueueConfig, QueuePlugin, QueueService, task
+from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
+from litestar_queues.events import publish_task_log, publish_task_progress
+
+
+@task("reports.render", queue="reports", retries=2, timeout=300)
+async def render_report(report_id: str) -> dict[str, str]:
+    await publish_task_log("Report rendering started", payload={"report_id": report_id})
+    await publish_task_progress(current=1, total=2, message="Rendering")
+    return {"report_id": report_id, "status": "rendered"}
+
+
+@task("scheduler.heartbeat", interval=timedelta(minutes=1), timeout=10)
+async def scheduler_heartbeat() -> None:
+    return None
+
+
+@post("/reports/{report_id:str}/render")
+async def enqueue_report(
+    report_id: str,
+    queue_service: NamedDependency[QueueService],
+) -> dict[str, str]:
+    result = await queue_service.enqueue(
+        render_report,
+        report_id,
+        key=f"report:{report_id}",
+        description="Render report",
+    )
+    return {"task_id": str(result.id), "status": result.status or "queued"}
+
+
+queue_config = QueueConfig(
+    queue_backend=SQLSpecBackendConfig(
+        config=AiosqliteConfig(connection_config={"database": "queue.db"}),
+        create_schema=False,
+        run_migrations=True,
+    ),
+    execution_backend="local",
+    in_app_worker=False,
+    worker_max_concurrency=4,
+)
+
+app = Litestar(
+    route_handlers=[enqueue_report],
+    plugins=[QueuePlugin(config=queue_config)],
+)
+```
+
+```bash
+LITESTAR_APP=app:app litestar queues run --queue reports --max-concurrency 4 --drain-timeout 60
+LITESTAR_APP=app:app litestar queues status --json
+LITESTAR_APP=app:app litestar queues scheduler-health --minutes 5
+```
+
+</example>
+
+## References Index
+
+- **[litestar](../litestar/SKILL.md)** — Litestar app setup, plugin lists, DI, and lifespan.
+- **[litestar-routing](../litestar-routing/SKILL.md)** — Controller and route handler patterns for enqueue endpoints.
+- **[litestar-realtime](../litestar-realtime/SKILL.md)** — Channels and WebSocket delivery for queue progress streams.
+- **[sqlspec](../sqlspec/SKILL.md)** — SQLSpec adapter and extension configuration.
+- **[advanced-alchemy](../advanced-alchemy/SKILL.md)** — Advanced Alchemy SQLAlchemy config, repositories, and Alembic ownership.
+
+## Official References
+
+- <https://github.com/cofin/litestar-queues/releases/tag/v0.1.0>
+- <https://github.com/cofin/litestar-queues>
+- <https://cofin.github.io/litestar-queues/>
+- <https://cofin.github.io/litestar-queues/usage/configuration.html>
+- <https://cofin.github.io/litestar-queues/usage/backends.html>
+- <https://cofin.github.io/litestar-queues/usage/tasks.html>
+- <https://cofin.github.io/litestar-queues/usage/workers.html>
+- <https://cofin.github.io/litestar-queues/usage/events.html>
+- <https://cofin.github.io/litestar-queues/usage/schedules.html>
+- <https://cofin.github.io/litestar-queues/usage/cli.html>
+- <https://cofin.github.io/litestar-queues/usage/dependency-resolver.html>
+
+## Shared Styleguide Baseline
+
+- Use shared styleguides for generic language/framework rules to reduce duplication in this skill.
+- [General Principles](../litestar-styleguide/references/general.md)
+- [Python](../litestar-styleguide/references/python.md)
+- [Litestar](../litestar-styleguide/references/litestar.md)
+- Keep this skill focused on `litestar-queues` workflows, backend selection, worker placement, and task/event APIs.

--- a/skills/litestar-vite/SKILL.md
+++ b/skills/litestar-vite/SKILL.md
@@ -11,6 +11,8 @@ The reference apps use `spa`, `template`, `htmx`, `hybrid` / `inertia`, `framewo
 
 The plugin pairs with the npm package [`litestar-vite-plugin`](https://www.npmjs.com/package/litestar-vite-plugin) on the JS side. Python `ViteConfig` is the source of truth; the generated `.litestar.json` bridge lets JS config normally keep only `litestar({ input: [...] })`.
 
+Current release note: `litestar-vite` `0.24.0` through `0.25.0` tightened SPA route exclusion, Inertia bootstrap/partial-reload behavior, Litestar 3 deprecation prep, and Vite 8.1 HMR config shape. See [Release Updates](references/release-updates.md).
+
 ## Code Style Rules
 
 - **Python**: PEP 604 unions (`T | None`); consumer Litestar app modules MAY use `from __future__ import annotations`.
@@ -273,7 +275,24 @@ Common HMR gotchas:
 - **Hot file mismatch**: remove JS `hotFile` overrides or align them with `ViteConfig.paths.hot_file`. Mismatch ⇒ stale prod URLs in dev.
 - **CORS errors**: use default proxy mode first. In direct/two-port mode, set `server.cors: true` so the Litestar origin can fetch dev assets.
 - **Port conflict**: proxy mode can auto-pick a Vite port. In direct/two-port mode, pin `runtime.port` and `server.port`.
+- **Vite 8.1 HMR deprecation**: put HMR network fields under `server.ws`, not `server.hmr`. Keep `server.hmr=false` only when disabling HMR. Use `server.hmr` network fields only when the project is pinned to Vite 7 or 8.0.
 - **Browsers cache `manifest.json`**: cache-bust by hash; never serve manifest.json from a CDN with long TTL.
+
+Vite 8.1+ explicit HMR network override:
+
+```ts
+export default defineConfig({
+  server: {
+    ws: {
+      host: "localhost",
+      path: "vite-hmr",
+      clientPort: 8000,
+    },
+  },
+})
+```
+
+Prefer no explicit HMR network override in proxy mode. Let `litestar-vite-plugin` write the version-correct config from the `.litestar.json` bridge.
 
 ### Production Build & Deploy
 
@@ -322,6 +341,13 @@ vite = VitePlugin(
 
 app = Litestar(plugins=[vite], middleware=[session_backend.middleware])
 ```
+
+Current Inertia behavior:
+
+- Initial non-Inertia visits return an HTML bootstrap. Inertia visits (`X-Inertia: true`) return JSON.
+- Handler returns shaped like prop bags (`dict`, `msgspec.Struct`, dataclass instance, or Pydantic model) become top-level page props. They are not nested under `content`.
+- Deferred props remain advertised on initial responses. A partial reload that resolves a deferred key strips that key from `deferredProps`; unrequested deferred keys stay advertised.
+- Use `litestar-vite-plugin` as the bridge owner. Do not add `@inertiajs/vite` to generated Litestar scaffolds by default.
 
 See `../litestar-inertia/SKILL.md` for client adapter setup.
 
@@ -381,6 +407,7 @@ For HTMX, register `HTMXPlugin()` and keep `ViteConfig(mode="htmx", ...)`.
 
 - **`ViteConfig` is the source of truth** — avoid JS-side `bundleDir`, `hotFile`, and `assetUrl` overrides unless this is a standalone/mono-repo override. Mismatch breaks HMR or manifest resolution silently.
 - **Use proxy mode by default** — Vite can auto-pick a port and the hot file carries the actual URL. Pin `server.port` only for direct/two-port workflows.
+- **Use `server.ws` for Vite 8.1+ HMR network overrides** — `server.hmr.host`, `server.hmr.port`, `server.hmr.clientPort`, `server.hmr.path`, `server.hmr.protocol`, and `server.hmr.timeout` are the Vite 7 / 8.0 shape.
 - **Set `server.cors: true` only for different public origins** — proxy mode keeps Litestar as the public origin.
 - **Toggle `dev_mode` from env**, never hardcode `True` in committed code — leaving dev mode on in prod proxies to a non-existent dev server.
 - **Keep `RuntimeConfig.start_dev_server=True` in dev** so `litestar run` starts/stops Vite. For prod, set `dev_mode=False`.
@@ -404,6 +431,7 @@ Before delivering a `litestar-vite` integration, verify:
 - [ ] JS-side `bundleDir` / `hotFile` / `assetUrl` overrides are absent or intentionally match `ViteConfig`
 - [ ] `dev_mode` is env-toggled
 - [ ] Direct/two-port workflows pin `server.port`; proxy-mode workflows do not rely on a fixed Vite port
+- [ ] Vite 8.1+ HMR network overrides use `server.ws`; Vite 7 / 8.0 overrides use `server.hmr`
 - [ ] `server.cors: true` only if Litestar and Vite are different public origins in dev
 - [ ] Template base file uses `vite_hmr()` before `vite(...)`
 - [ ] If `types=TypeGenConfig(...)`, generated types are committed or CI verifies they are up-to-date
@@ -504,6 +532,7 @@ For deep-dives on specific surfaces, see:
 - **[HMR](references/hmr.md)** — HMR architecture, debugging, common pitfalls.
 - **[Deployment](references/deployment.md)** — Production build, static hosting, CDN patterns, cache strategy.
 - **[Troubleshooting](references/troubleshooting.md)** — Common errors and fixes.
+- **[Release Updates](references/release-updates.md)** — `litestar-vite` `0.24.0` through `0.25.0` behavior changes.
 
 ## Cross-References
 

--- a/skills/litestar-vite/references/config.md
+++ b/skills/litestar-vite/references/config.md
@@ -83,6 +83,8 @@ Also configure Vite top-level:
 | `base` | Asset URL base; CDN URL in prod |
 | `publicDir` | Static files copied verbatim |
 | `server.port` | Optional in proxy mode; pin for direct/external two-port workflows |
+| `server.ws` | Vite 8.1+ HMR network overrides (`host`, `port`, `clientPort`, `path`, `protocol`, `timeout`) |
+| `server.hmr` | Vite 7 / 8.0 HMR network overrides; `false` disables HMR |
 | `server.cors: true` | Only needed when Litestar and Vite are different public origins |
 | `build.outDir` | Match `bundle_dir` |
 | `build.emptyOutDir` | `true` to avoid stale assets |

--- a/skills/litestar-vite/references/hmr.md
+++ b/skills/litestar-vite/references/hmr.md
@@ -27,6 +27,32 @@ In dev mode:
 
 React projects get Fast Refresh through the Vite React plugin and HMR client. Keep `vite_hmr()` before the entrypoint tag.
 
+## Vite 8.1+ HMR Config Shape
+
+Vite 8.1 moved HMR network options from `server.hmr.*` to `server.ws.*`.
+
+Use this shape only when you must override the network settings explicitly:
+
+```ts
+export default defineConfig({
+  server: {
+    ws: {
+      host: "localhost",
+      path: "vite-hmr",
+      clientPort: 8000,
+      protocol: "ws",
+    },
+  },
+})
+```
+
+Rules:
+
+- Vite 8.1+: place `host`, `port`, `clientPort`, `path`, `protocol`, and `timeout` under `server.ws`.
+- Vite 7 / 8.0: place those fields under `server.hmr`.
+- Disabling HMR remains `server.hmr = false`.
+- In proxy mode, omit explicit HMR network settings unless the default bridge-derived values are wrong.
+
 ## Common Issues
 
 ### Stale prod URLs in dev
@@ -52,6 +78,12 @@ Fix: first use the default proxy mode so Litestar is the public origin. In direc
 Symptom: HMR works some runs, fails others. Asset URLs point at unexpected ports.
 
 Fix: in proxy mode, let Vite auto-pick and read the generated hot-file URL. In direct/two-port mode, pin both `RuntimeConfig.port` (Python) and `server.port` (JS) to the same value.
+
+### Vite 8.1 HMR deprecation warning
+
+Symptom: Vite logs that `server.hmr.*` network options are deprecated.
+
+Fix: move HMR network options to `server.ws` when running Vite 8.1+. If the project must support Vite 7 or 8.0 from the same `vite.config.ts`, avoid explicit HMR network config and let `litestar-vite-plugin` emit the version-gated shape.
 
 ### HMR works but full reloads happen
 
@@ -86,5 +118,6 @@ Fix: never set long TTL on `manifest.json`. Hash the bundles (Vite default), but
 - [ ] `hot_file` exists at the configured path during a dev session
 - [ ] Browser network tab shows JS fetched through Litestar's proxy in default mode, or from the pinned Vite origin in direct mode
 - [ ] `vite_hmr()` rendered to a `<script>` tag in the served HTML
+- [ ] Vite 8.1+ configs use `server.ws` for HMR network fields
 - [ ] Browser console shows `[vite] connected`
 - [ ] WebSocket frames appear in network tab on file edit

--- a/skills/litestar-vite/references/modes.md
+++ b/skills/litestar-vite/references/modes.md
@@ -251,6 +251,8 @@ See [`../../litestar-htmx/SKILL.md`](../../litestar-htmx/SKILL.md) for the full 
 - Page components live in `resources/js/pages/<component>/<name>.tsx`
 - Configure one `VitePlugin` with `ViteConfig(inertia=InertiaConfig(...))`
 - Page-prop type generation via `TypeGenConfig` + Inertia's schema
+- `dict`, `msgspec.Struct`, dataclass, and Pydantic handler returns are prop bags: initial visits bootstrap HTML, and Inertia visits spread fields as top-level props
+- Deferred props advertise metadata on initial responses; partial reloads strip only the keys they just resolved from `deferredProps`
 
 ```python
 from litestar import Controller, Litestar, get

--- a/skills/litestar-vite/references/release-updates.md
+++ b/skills/litestar-vite/references/release-updates.md
@@ -1,0 +1,54 @@
+# litestar-vite - Release Updates 0.24.0 to 0.25.0
+
+Use this file when refreshing guidance against current upstream `litestar-vite` releases.
+
+## Release Anchors
+
+| Version | Upstream change | Skill guidance |
+| --- | --- | --- |
+| `0.24.0` | SPA handler excludes its own routes from Litestar route-prefix detection. | Non-root `spa_path` values such as `/ui` remain reachable while real backend routes still win. If `/ui/...` fails with `Not an SPA route`, upgrade before adding local workarounds. |
+| `0.24.0` | Deferred Inertia props strip resolved keys from `deferredProps` on partial reload. | Initial responses still advertise deferred metadata. Partial reload responses remove only keys they resolved; unrequested deferred props remain advertised. |
+| `0.24.0` | Litestar 3 deprecation prep and Inertia integration cleanup. | Use `litestar.plugins.jinja.JinjaTemplateEngine` in examples. Keep `litestar-vite-plugin` as the Litestar bridge owner; do not add `@inertiajs/vite` to generated scaffolds by default. |
+| `0.24.1` | Structured Inertia handler returns bootstrap as HTML props. | `dict`, `msgspec.Struct`, dataclass, and Pydantic model returns are prop bags. Initial visits return HTML; Inertia visits spread fields as top-level props. |
+| `0.25.0` | Vite 8.1 HMR `server.ws.*` deprecation fix. | Vite 8.1+ HMR network fields belong under `server.ws`; Vite 7 / 8.0 use `server.hmr`; `server.hmr=false` still disables HMR. |
+
+## Vite 8.1 HMR Shape
+
+Prefer no explicit HMR network override in proxy mode. Let `litestar-vite-plugin` emit the version-gated shape from the `.litestar.json` bridge.
+
+When an override is required on Vite 8.1+:
+
+```ts
+export default defineConfig({
+  server: {
+    ws: {
+      host: "localhost",
+      path: "vite-hmr",
+      clientPort: 8000,
+    },
+  },
+})
+```
+
+Do not place `host`, `port`, `clientPort`, `path`, `protocol`, or `timeout` under `server.hmr` on Vite 8.1+. Use that legacy shape only for Vite 7 or 8.0.
+
+## Inertia Behavior
+
+- Treat `dict`, `msgspec.Struct`, dataclass, and Pydantic model handler returns as shallow prop bags.
+- Initial non-Inertia visits return HTML bootstrap responses.
+- Inertia visits (`X-Inertia: true`) return JSON with fields as top-level props.
+- Deferred props are advertised on initial responses.
+- A partial reload that resolves a deferred prop removes that key from `deferredProps`; it does not remove unrelated deferred keys.
+- Keep `litestar-vite-plugin` responsible for the bridge, dev/prod asset resolution, proxy routing, type generation, CSRF helper wiring, and `resolvePageComponent()`.
+
+## Upstream Sources
+
+- `v0.24.0` release: <https://github.com/litestar-org/litestar-vite/releases/tag/v0.24.0>
+- `v0.24.1` release: <https://github.com/litestar-org/litestar-vite/releases/tag/v0.24.1>
+- `v0.25.0` release: <https://github.com/litestar-org/litestar-vite/releases/tag/v0.25.0>
+- SPA route exclusion: <https://github.com/litestar-org/litestar-vite/pull/264>
+- Deferred props partial reload fix: <https://github.com/litestar-org/litestar-vite/pull/265>
+- Litestar 3 and Inertia integration prep: <https://github.com/litestar-org/litestar-vite/pull/269>
+- Structured Inertia bootstrap returns: <https://github.com/litestar-org/litestar-vite/pull/277>
+- Vite 8.1 HMR shape: <https://github.com/litestar-org/litestar-vite/pull/293>
+- Vite server options: <https://vite.dev/config/server-options>

--- a/skills/litestar-vite/references/troubleshooting.md
+++ b/skills/litestar-vite/references/troubleshooting.md
@@ -18,6 +18,7 @@ See `hmr.md` for the full debug checklist. Quick summary:
 - Vite not actually running (check `litestar run` logs)
 - CORS / port mismatch in direct mode
 - Missing `vite_hmr()` in template
+- Vite 8.1+ config still puts HMR network fields under `server.hmr` instead of `server.ws`
 
 ## Type Generation Fails
 
@@ -44,6 +45,15 @@ See `hmr.md` for the full debug checklist. Quick summary:
 | Page renders as JSON, not HTML | `ViteConfig.inertia` missing or route lacks `component=` / Inertia response helper | Add `InertiaConfig(...)` to `ViteConfig`; set `mode="hybrid"` when explicit mode is needed |
 | Type errors on page props | `inertia-pages.json` / `page-props.ts` stale | Re-run `litestar assets generate-types` |
 | First-load works, navigations break | `root_template` missing Inertia head tags | Use Inertia layout pattern in `base.html` |
+| Structured handler return nests under `content` or boots as JSON | Running pre-0.24.1 behavior or bypassing the Inertia wrapper | Upgrade to `litestar-vite>=0.24.1`; return a prop bag from a `component=` handler |
+| Deferred props loop after partial reload | Resolved keys are echoed back in `deferredProps` | Upgrade to `litestar-vite>=0.24.0`; resolved partial-reload keys are stripped from metadata |
+
+## SPA Catch-All Issues
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Non-root `spa_path` such as `/ui` returns `Not an SPA route` | SPA handler's own route is treated as a non-SPA Litestar route in pre-0.24.0 versions | Upgrade to `litestar-vite>=0.24.0`; keep real API routes registered normally |
+| API routes return SPA HTML | Catch-all SPA route is too broad or registered before explicit routes | Register explicit API routes and let SPA fallback serve only non-Litestar paths |
 
 ## Performance
 

--- a/skills/sqlspec/SKILL.md
+++ b/skills/sqlspec/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: sqlspec
-description: "Auto-activate for sqlspec, SQLSpec, SQLFileLoader, drivers, query builders, named SQL, filters, pagination, Arrow, framework extensions, ADK stores, data dictionary, or observers. Not for ORM repositories."
+description: "Auto-activate for sqlspec, SQLSpec, SQLFileLoader, drivers, query builders, named SQL, filters, pagination, Arrow, framework extensions, ADK stores, data dictionary, or observers. Not for ORM repositories -- use advanced-alchemy."
 ---
 
 # SQLSpec Skill
 
-SQLSpec is a **type-safe SQL query mapper for Python** -- NOT an ORM. It provides flexible connectivity with consistent interfaces across 18+ database adapters. Write raw SQL, use the builder API, or load SQL from files. All statements pass through a sqlglot-powered AST pipeline for validation and dialect conversion.
+SQLSpec is a **type-safe SQL query mapper for Python** -- NOT an ORM. It provides flexible connectivity with consistent interfaces across 18+ database adapters. Write raw SQL, use the builder API, or load SQL from files. Statements pass through a sqlglot-powered AST pipeline for validation, parameter handling, and dialect conversion.
 
 ## Match-Your-Framework — read first
 
@@ -46,9 +46,9 @@ db_manager.add_config(config)
 
 # Use SQLSpec's session provider for connection lifecycle
 async with db_manager.provide_session(config) as db:
-    users = await db.select_many(
+    users = await db.select(
         "SELECT * FROM users WHERE active = $1",
-        [True],
+        True,
         schema_type=User,
     )
 ```
@@ -91,24 +91,37 @@ stmt = (
 
 | Method | Returns | Use Case |
 | --- | --- | --- |
+| `select()` / `fetch()` | List of rows | Filtered queries, listing |
 | `select_value()` | Single scalar | `COUNT(*)`, `MAX()`, existence checks |
+| `select_value_or_none()` | Scalar or `None` | Optional scalar lookup |
 | `select_one()` | One row (strict) | Get-by-ID, raises `NotFoundError` |
 | `select_one_or_none()` | One row or `None` | Optional lookup |
-| `select_many()` | List of rows | Filtered queries, listing |
-| `select_to_arrow()` | `pyarrow.Table` | Bulk data export, analytics |
-| `execute()` | Row count | INSERT/UPDATE/DELETE |
-| `execute_many()` | Row count | Batch operations |
+| `select_with_total()` | Rows plus total | Pagination |
+| `select_stream()` / `fetch_stream()` | Context-managed row stream | Bounded row iteration where adapter supports native streaming |
+| `select_to_arrow()` / `fetch_to_arrow()` | `ArrowResult` | Bulk data export, analytics |
+| `execute()` | `SQLResult` | INSERT/UPDATE/DELETE metadata |
+| `execute_many()` | `SQLResult` | Batch operation metadata |
+| `load_from_arrow()` | `StorageBridgeJob` | Native Arrow bulk ingest |
+| `load_from_storage()` | `StorageBridgeJob` | Load staged files or cloud URIs |
+| `load_from_records()` | `StorageBridgeJob` | Native bulk ingest for in-memory records |
 
 ### Arrow Integration Basics
 
 ```python
-# Zero-copy on DuckDB, ADBC adapters; conversion on others
-arrow_table = await db.select_to_arrow(
-    "SELECT * FROM large_dataset WHERE region = $1", [region]
+# Native Arrow on ADBC, DuckDB, BigQuery, Spanner, mssql-python, arrow-odbc,
+# and oracledb; conversion path on other adapters unless native_only=True.
+arrow_result = await db.select_to_arrow(
+    "SELECT * FROM large_dataset WHERE region = $1",
+    region,
+    return_format="reader",
+    batch_size=10_000,
 )
 
 # Bulk load from Arrow
-await db.copy_from_arrow(arrow_table, target_table="users")
+await db.load_from_arrow("users", arrow_result)
+
+# Bulk load records through the same native ingest path
+await db.load_from_records("users", [{"id": 1, "name": "Ada"}])
 ```
 
 <workflow>
@@ -122,13 +135,14 @@ await db.copy_from_arrow(arrow_table, target_table="users")
 | PostgreSQL async | `asyncpg`, `psycopg` | Async, NUMERIC/PYFORMAT params |
 | PostgreSQL sync | `psycopg` | Sync+async, PYFORMAT params |
 | SQLite | `sqlite`, `aiosqlite` | QMARK params, local dev |
-| DuckDB analytics | `duckdb` | Arrow-native, zero-copy |
+| DuckDB analytics | `duckdb` | Arrow-native OLAP, extension load/install lifecycle |
 | MySQL async | `asyncmy` | PYFORMAT params |
 | Oracle | `oracledb` | NAMED_COLON params, sync+async |
-| BigQuery / Spanner | `bigquery`, `spanner` | NAMED_AT params |
-| Raw SQL strings | Driver methods | `select_many()`, `execute()` |
+| BigQuery / Spanner | `bigquery`, `spanner` | NAMED_AT params, cloud job/session controls |
+| Raw SQL strings | Driver methods | `select()`, `execute()` |
 | Dynamic queries | Query builder | `sql.select()...to_statement()` |
-| SQL from files | `SQLFileLoader` | Metadata directives, caching |
+| SQL from files | `SQLFileLoader` | Metadata directives, `-- param:` declarations, caching |
+| High-volume ingest | Storage bridge | `load_from_arrow()`, `load_from_storage()`, `load_from_records()` |
 
 ### Step 2: Implement
 
@@ -137,6 +151,8 @@ await db.copy_from_arrow(arrow_table, target_table="users")
 3. Choose the appropriate driver method for your query shape
 4. Use `schema_type` parameter for typed results (Pydantic or msgspec models)
 5. Apply filters with `LimitOffsetFilter`, `OrderByFilter`, `SearchFilter`
+6. Use `select_stream(..., native_only=True)` when bounded-memory streaming is mandatory
+7. Use `load_from_records()` or `load_from_arrow()` for high-volume ingest; avoid row-by-row `execute_many()` for bulk pipelines
 
 ### Step 3: Validate
 
@@ -153,9 +169,13 @@ Run through the validation checkpoint below before considering the work complete
 - **Always use context managers** for driver lifecycle -- `async with db_manager.provide_session(config) as db:`
 - **Prefer the query builder** for complex dynamic queries -- avoids string concatenation, handles dialect conversion
 - **Prefer `SQLFileLoader`** for static queries -- keeps SQL out of Python, enables caching
+- **Use `-- param:` declarations for named SQL files that cross service boundaries** -- load-time and execute-time validation catches name drift and required parameter omissions
+- **Use `native_only=True` for streaming or Arrow paths only when fallback is unacceptable** -- unsupported adapters otherwise use eager row conversion
+- **Pass regular query bind values as positional arguments** -- `await db.select("... WHERE id = $1", user_id, schema_type=User)`, not `await db.select(..., [user_id], ...)`
 - **Never concatenate SQL strings** -- use parameterized queries or the query builder
 - **Never hold connections outside context managers** -- connection leaks exhaust the pool
 - **Match parameter style to adapter**: `$1` for asyncpg, `%s` for psycopg, `?` for sqlite, `:name` for oracledb
+- **Do not invent adapter APIs** -- BigQuery job controls live in `driver_features`; Spanner request controls live in `driver_features` or `provide_session()` kwargs
 - **Adapter config / driver modules avoid `from __future__ import annotations`**. Consumer app modules MAY use it.
 
 </guardrails>
@@ -172,6 +192,9 @@ Before delivering SQLSpec code, verify:
 - [ ] Query results use `schema_type` for type-safe mapping
 - [ ] Complex dynamic queries use the builder API, not string concatenation
 - [ ] Filters use SQLSpec filter objects (`LimitOffsetFilter`, etc.) not manual LIMIT/OFFSET
+- [ ] Streaming code uses context managers and sets `native_only=True` when eager fallback would be a bug
+- [ ] Bulk ingest code uses `load_from_arrow()`, `load_from_storage()`, or `load_from_records()` and checks adapter gates such as MySQL local-infile, Oracle direct path load, BigQuery Storage Write API, or Spanner Batch Write API
+- [ ] ADK stores are selected from supported adapter `adk` packages; BigQuery is not an ADK backend
 
 </validation>
 
@@ -220,9 +243,9 @@ async def list_active_users(page: int = 1, page_size: int = 25) -> list[User]:
     ]
 
     async with db_manager.provide_session(config) as db:
-        users = await db.select_many(
+        users = await db.select(
             "SELECT id, name, email, active FROM users WHERE active = $1",
-            [True],
+            True,
             *filters,
             schema_type=User,
         )
@@ -232,80 +255,16 @@ async def list_active_users(page: int = 1, page_size: int = 25) -> list[User]:
 async def get_user_count() -> int:
     async with db_manager.provide_session(config) as db:
         count = await db.select_value(
-            "SELECT COUNT(*) FROM users WHERE active = $1", [True]
+            "SELECT COUNT(*) FROM users WHERE active = $1", True
         )
         return count
 ```
 
 </example>
 
-## Query Builder
-
-The `sql` factory provides a fluent builder API with full method chaining. All builders terminate with `.to_statement()` and pass through sqlglot for validation and dialect conversion.
-
-| Builder | Entry Point | Key Methods |
-| --- | --- | --- |
-| SELECT | `sql.select(*cols)` | `.from_()`, `.where()`, `.where_eq()`, `.join()`, `.order_by()`, `.limit()`, `.offset()` |
-| INSERT | `sql.insert(table)` | `.columns()`, `.values()`, `.returning()` |
-| UPDATE | `sql.update(table)` | `.set_()`, `.where()`, `.returning()` |
-| DELETE | `sql.delete(table)` | `.where()`, `.returning()` |
-| MERGE | `sql.merge_(target)` | `.using()`, `.when_matched()`, `.when_not_matched()` |
-| CREATE TABLE | `sql.create_table(name)` | `.column()`, `.primary_key()`, `.if_not_exists()` |
-| DROP TABLE | `sql.drop_table(name)` | `.if_exists()`, `.cascade()` |
-
-## ArrowResult
-
-`select_to_arrow()` returns an Apache Arrow `Table` for bulk and analytical workloads:
-
-- **Zero-copy** on DuckDB and ADBC-native adapters — no serialization overhead
-- **Conversion path** on other adapters — rows are materialized into an Arrow schema
-- Returned tables are compatible with Polars, Pandas, and PyArrow directly
-- Use `copy_from_arrow(table, target_table)` for bulk loads back into the database
-
-## Filters
-
-SQLSpec filter objects are passed directly to driver methods alongside the SQL string. They modify the statement before execution.
-
-| Filter | Purpose | Example Use |
-| --- | --- | --- |
-| `BeforeAfterFilter` | Date range bounds (`before`, `after`) | Audit log queries, time-range pagination |
-| `InCollectionFilter` | SQL `IN (...)` clause | Filter by a set of IDs or enum values |
-| `LimitOffsetFilter` | Page-based pagination | `limit=25, offset=50` |
-| `OrderByFilter` | Dynamic sort columns and direction | User-supplied sort fields |
-| `SearchFilter` | Text search (`ILIKE` / `LIKE`) | Full-text style search on string columns |
-
-Filters are composable — pass multiple to a single `select_many()` call and they are applied in order.
-
-## Framework Integrations
-
-| Framework | Integration | Key Feature |
-| --- | --- | --- |
-| Litestar | `SQLSpecPlugin` | Dependency injection of typed driver; auto session lifecycle |
-| FastAPI / Starlette | Middleware | Request-scoped connection; injects driver into route dependencies |
-| Flask | Extension | `init_app()` pattern; driver available via `g` or `current_app` |
-
-`SQLSpecPlugin` for Litestar registers the driver as a DI provider — inject it into route handlers via type annotation without manual context management.
-
-## Event Channels
-
-For databases that support server-side pub/sub (e.g., PostgreSQL `LISTEN`/`NOTIFY`):
-
-- Use `AsyncEventChannel` to subscribe to named channels
-- Publish with `NOTIFY channel, payload` from SQL or from the `publish()` method
-- Handlers receive `EventMessage` objects with channel name, payload, and PID
-- Useful for real-time cache invalidation, cross-process coordination, and background job triggers
-
-## Key Design Principles
-
-1. **Single Source of Truth**: The `SQL` object holds all state for a given statement
-2. **Immutability**: All operations on a `SQL` object return new instances
-3. **Type Safety**: Parameters carry type information through the processing pipeline
-4. **Protocol-Based Design**: Uses Python protocols for runtime type checking instead of inheritance
-5. **Single-Pass Processing**: Parse once, transform once, validate once
-
 ## References Index
 
-> **Choosing between `sqlspec` and `advanced-alchemy`:** `advanced-alchemy` gives you an opinionated ORM service layer with `UUIDAuditBase`, lifecycle hooks, repository / service / Alembic integration, and `OffsetPagination[T]` out of the box — pick it when you want a complete CRUD surface with attribute-style row access and you're happy inside the SQLAlchemy ecosystem. `sqlspec` gives you direct SQL control, 18+ driver adapters (asyncpg, oracledb, DuckDB, BigQuery, SQLite, and more), Arrow-native result streams for analytics, and a builder API when you need it — pick it when you want explicit SQL, heterogeneous database backends, or Arrow integration. Both skills integrate with Litestar via first-party plugins; see [`../advanced-alchemy/SKILL.md`](../advanced-alchemy/SKILL.md) for the ORM path.
+> **Choosing between `sqlspec` and `advanced-alchemy`:** `advanced-alchemy` gives you an opinionated ORM service layer with `UUIDAuditBase`, lifecycle hooks, repository / service / Alembic integration, and `OffsetPagination[T]` out of the box — pick it when you want a complete CRUD surface with attribute-style row access and you're happy inside the SQLAlchemy ecosystem. `sqlspec` gives you direct SQL control, 18+ driver adapters (asyncpg, oracledb, DuckDB, BigQuery, SQLite, and more), Arrow result paths for analytics, and a builder API when you need it — pick it when you want explicit SQL, heterogeneous database backends, or Arrow integration. Both skills integrate with Litestar via first-party plugins; see [`../advanced-alchemy/SKILL.md`](../advanced-alchemy/SKILL.md) for the ORM path.
 
 For detailed instructions, patterns, and API guides, refer to the following documents:
 
@@ -319,18 +278,20 @@ For detailed instructions, patterns, and API guides, refer to the following docu
 
 ### Architecture & Performance
 
-- **[Architecture & Caching](references/architecture.md)** -- Core data flow, NamespacedCache system, Mypyc compilation.
-- **[Data Dictionary](references/data-dictionary.md)** -- Dialect feature flags, runtime introspection (`get_tables`, `get_columns`, `get_indexes`), driver-side metadata API.
+- **[Architecture & Caching](references/architecture.md)** -- Core data flow, NamespacedCache system, statement/cache tuning, Mypyc compilation.
+- **[Performance & Cloud Controls](references/performance.md)** -- Bounded async bridge, cache/fetch tuning, BigQuery job controls, Spanner session controls.
+- **[Data Dictionary](references/data-dictionary.md)** -- Dialect feature flags, runtime introspection (`get_tables`, `get_columns`, `get_indexes`), ADBC native metadata/statistics.
 
 ### Query Building & Execution
 
 - **[Query Builder API](references/query_builder.md)** -- `sql` factory: select, insert, update, delete, merge.
-- **[Driver Method Reference](references/driver_api.md)** -- `select_value()`, `select_one()`, `select_many()`, `select_to_arrow()`.
+- **[Driver Method Reference](references/driver_api.md)** -- `select()`, `select_one()`, `select_stream()`, `select_to_arrow()`, load methods.
 - **[Filter & Pagination System](references/filters.md)** -- `LimitOffsetFilter`, `OrderByFilter`, `SearchFilter`.
 
 ### Data Integration
 
-- **[Arrow & ADBC Integration](references/arrow.md)** -- `select_to_arrow()` zero-copy, `copy_from_arrow()` bulk loading.
+- **[Arrow & ADBC Integration](references/arrow.md)** -- `select_to_arrow()` formats, Arrow-native paths, conversion fallbacks.
+- **[Native Bulk Ingest](references/bulk-ingest.md)** -- `load_from_arrow()`, `load_from_storage()`, `load_from_records()`, adapter gates.
 - **[SQL File Loading](references/loader.md)** -- `SQLFileLoader` with search paths, metadata directives.
 
 ### Adapters & Drivers
@@ -342,7 +303,7 @@ For detailed instructions, patterns, and API guides, refer to the following docu
 - **[Framework Extensions](references/extensions.md)** -- Litestar plugin, FastAPI/Starlette integration.
 - **[Storage Integration](references/storage.md)** -- ADK store, Litestar session stores, event channel backends.
 - **[Event Channels (Pub/Sub)](references/events.md)** -- `AsyncEventChannel`, subscribe/publish patterns.
-- **[ADK Extension](references/adk.md)** -- `SQLSpecSessionService`, `SQLSpecMemoryService`, `SQLSpecArtifactService`, per-adapter ADK stores.
+- **[ADK Extension](references/adk.md)** -- ADK 2 session/memory stores, scoped state, artifact service contracts.
 
 ### Migrations & Schema
 

--- a/skills/sqlspec/references/adapters.md
+++ b/skills/sqlspec/references/adapters.md
@@ -10,23 +10,37 @@
 | Arrow ODBC | `"arrow_odbc"` | dynamic | QMARK (`?`) | `helper` | No | Arrow-native |
 | AsyncMy | `"asyncmy"` | `mysql` | PYFORMAT (`%s`) | `helper` | Yes | MySQL native |
 | AsyncPG | `"asyncpg"` | `postgres` | NUMERIC (`$1`) | `driver` | Yes | asyncpg codecs |
-| BigQuery | `"bigquery"` | `bigquery` | NAMED_AT (`@name`) | `helper` | Yes | BQ type mapping |
+| BigQuery | `"bigquery"` | `bigquery` | NAMED_AT (`@name`) | `helper` | No | BQ type mapping |
 | CockroachDB Asyncpg | `"cockroach_asyncpg"` | `postgres` | NUMERIC (`$1`) | `driver` | Yes | asyncpg codecs |
 | CockroachDB Psycopg | `"cockroach_psycopg"` | `postgres` | PYFORMAT (`%s`) | `helper` | Yes | psycopg adapt |
 | DuckDB | `"duckdb"` | `duckdb` | QMARK (`?`) | `helper` | No | Arrow-native |
 | MSSQL Python | `"mssql_python"` | `tsql` | QMARK (`?`) | `helper` | Both | SQL Server native |
-| MysqlConnector | `"mysql_connector"` | `mysql` | PYFORMAT (`%s`) | `helper` | No | MySQL native |
+| MysqlConnector | `"mysqlconnector"` | `mysql` | PYFORMAT (`%s`) | `helper` | Both | MySQL native |
 | OracleDB | `"oracledb"` | `oracle` | NAMED_COLON (`:name`) | `helper` | Both | Oracle DB API |
 | PSQLPy | `"psqlpy"` | `postgres` | NUMERIC (`$1`) | `helper` | Yes | Rust-backed |
 | Psycopg | `"psycopg"` | `postgres` | PYFORMAT (`%s`) | `helper` | Both | psycopg adapt |
 | PyMySQL | `"pymysql"` | `mysql` | PYFORMAT (`%s`) | `helper` | No | MySQL native |
-| Spanner | `"spanner"` | `spanner` | NAMED_AT (`@name`) | `helper` | Yes | Spanner proto |
+| Spanner | `"spanner"` | `spanner` | NAMED_AT (`@name`) | `helper` | No | Spanner proto |
 | SQLite | `"sqlite"` | `sqlite` | QMARK (`?`) | `helper` | No | Python stdlib |
 
 ### JSON Strategy
 
 - **`driver`**: The database driver handles JSON serialization natively (AsyncPG, CockroachDB Asyncpg). Zero overhead.
 - **`helper`**: SQLSpec serializes JSON values before binding. Works universally.
+
+---
+
+## Capability Snapshot
+
+Check the adapter config flags before building generic tooling:
+
+| Capability | Native adapters | Caveats |
+| --- | --- | --- |
+| Row streaming with `select_stream()` / `fetch_stream()` | `asyncpg`, `cockroach_asyncpg`, `psycopg`, `cockroach_psycopg`, `psqlpy`, `pymysql`, `aiomysql`, `asyncmy`, `mysqlconnector`, `sqlite`, `aiosqlite`, `oracledb`, `bigquery` | `adbc`, `duckdb`, `mssql_python`, `arrow_odbc`, and `spanner` use eager fallback only. Use `native_only=True` when fallback would violate memory bounds. |
+| Arrow export with native `select_to_arrow()` override | `adbc`, `arrow_odbc`, `duckdb`, `bigquery`, `spanner`, `mssql_python`, `oracledb` | Other adapters use the base dict-to-Arrow conversion for `select_to_arrow()`; `native_only=True` raises there. `config.supports_arrow_streaming` is a streaming capability flag, not a separate API. |
+| Native ingest through `load_from_arrow()` / `load_from_records()` | PostgreSQL family, MySQL family, SQLite family, `adbc`, `duckdb`, `oracledb`, `bigquery`, `spanner`, `mssql_python`, `arrow_odbc` | `load_from_records()` normalizes to Arrow first. MySQL local-infile, Oracle direct path load, BigQuery Storage Write API, and Spanner Batch Write API have explicit gates. |
+| ADK session/event and memory stores | `asyncpg`, `psycopg`, `psqlpy`, `cockroach_asyncpg`, `cockroach_psycopg`, `aiomysql`, `asyncmy`, `mysqlconnector`, `pymysql`, `aiosqlite`, `sqlite`, `oracledb`, `duckdb`, `adbc`, `spanner` | BigQuery and `mssql_python` are not ADK backends. Artifact service contracts exist, but concrete adapter artifact metadata stores are deployment-provided. |
+| Cloud job/session controls | `bigquery`, `spanner` | BigQuery controls live in `BigQueryConfig.driver_features`; Spanner controls live in `SpannerSyncConfig.driver_features`, per-call kwargs, and `provide_session()` / `provide_read_session()`. |
 
 ---
 
@@ -90,7 +104,7 @@ Each adapter's `core.py` module exports these helpers:
 
 ### PostgreSQL
 
-- **asyncpg**: Best throughput, native JSON/UUID, zero-copy Arrow. Use for high-performance async apps.
+- **asyncpg**: Best throughput, native JSON/UUID, and PostgreSQL COPY ingest. Use for high-performance async apps.
 - **psycopg**: Broadest compatibility, sync + async, PgBouncer-friendly. Use when you need sync or connection pooling.
 - **psqlpy**: Rust-backed async driver. Use when you want Rust performance with Python ergonomics.
 - **cockroach_asyncpg / cockroach_psycopg**: CockroachDB-specific. Built-in retry logic for serialization conflicts (`40001`), follower reads.
@@ -99,7 +113,7 @@ Each adapter's `core.py` module exports these helpers:
 
 - **asyncmy**: Async MySQL with good performance. Use for async applications.
 - **pymysql**: Pure Python sync driver. Use for simple scripts or when C extensions are unavailable.
-- **mysql_connector**: Oracle's official connector. Use when vendor support matters.
+- **mysqlconnector**: Oracle's official connector. Use when vendor support matters.
 
 ### SQLite
 
@@ -167,8 +181,9 @@ class MyDriver(SyncDriverAdapterBase):
 
 ### DuckDB
 
-- Native Apache Arrow support with zero-copy for `select_to_arrow()` and `copy_from_arrow()`.
+- Native Apache Arrow support for `select_to_arrow()` and `load_from_arrow()`.
 - Best for in-memory analytics and local OLAP workloads.
+- `DuckDBExtensionConfig` separates install and load lifecycle: `install=True` forces an `install_extension()` call, `force_install=True` reinstalls, and `required=True` turns load/install failures from best-effort warnings into exceptions.
 
 ### BigQuery
 

--- a/skills/sqlspec/references/adk.md
+++ b/skills/sqlspec/references/adk.md
@@ -1,12 +1,12 @@
 # SQLSpec ADK Extension
 
-`sqlspec.extensions.adk` is the SQL-backed storage layer for Google's **Agent Development Kit (ADK)** session, memory, and artifact abstractions. ADK defines abstract services (`BaseSessionService`, `BaseMemoryService`, `BaseArtifactService`); SQLSpec ships concrete SQL-backed implementations that plug into any adapter.
+`sqlspec.extensions.adk` is the SQL-backed storage layer for Google's **Agent Development Kit (ADK)** session, event, and memory abstractions. ADK defines abstract services (`BaseSessionService`, `BaseMemoryService`, `BaseArtifactService`); SQLSpec ships session/event and memory implementations for supported adapters plus artifact service contracts for deployments that provide a concrete artifact metadata store.
 
 ## What ADK Is
 
-Google's ADK is a Python framework for building LLM agents (`LlmAgent`, `Runner`, tool calls, structured events). ADK is storage-agnostic — you point it at a session service, memory service, and (optionally) an artifact service, and it persists state across turns. SQLSpec's `extensions.adk` module provides those three services backed by a real database rather than in-memory dicts.
+Google's ADK is a Python framework for building LLM agents (`LlmAgent`, `Runner`, tool calls, structured events). ADK is storage-agnostic — you point it at a session service, memory service, and (optionally) an artifact service, and it persists state across turns. SQLSpec's `extensions.adk` module provides database-backed session and memory services, plus an artifact service when paired with a concrete artifact metadata store.
 
-## The Three Stores
+## Store Surface
 
 All store classes live under `sqlspec.extensions.adk`. Each has an async base (used by async adapters) and a sync base (used by sync adapters):
 
@@ -14,13 +14,13 @@ All store classes live under `sqlspec.extensions.adk`. Each has an async base (u
 | --- | --- | --- | --- |
 | `BaseAsyncADKStore` / `BaseSyncADKStore` | Conversation sessions + full event history | `SQLSpecSessionService` | `SessionRecord`, `EventRecord` |
 | `BaseAsyncADKMemoryStore` / `BaseSyncADKMemoryStore` | Long-term memory entries searchable per user | `SQLSpecMemoryService`, `SQLSpecSyncMemoryService` | `MemoryRecord` |
-| `BaseAsyncADKArtifactStore` / `BaseSyncADKArtifactStore` | Versioned artifact **metadata** (content lives in object storage) | `SQLSpecArtifactService` | `ArtifactRecord` |
+| `BaseAsyncADKArtifactStore` / `BaseSyncADKArtifactStore` | Versioned artifact **metadata** contract (content lives in object storage) | `SQLSpecArtifactService` | `ArtifactRecord` |
 
-All records are `TypedDict`s (see `sqlspec/extensions/adk/_types.py`, `memory/_types.py`, `artifact/_types.py`) so mypyc can compile the service layer without pulling in Pydantic at runtime.
+All records are `TypedDict`s (see `sqlspec/extensions/adk/_types.py`, `memory/_types.py`, `artifact/_types.py`) so mypyc can compile the service layer without pulling in Pydantic at runtime. Adapter support guarantees cover session/event and memory stores. Adapter-specific concrete artifact metadata stores are not part of the support matrix.
 
 ### Session store
 
-Stores one row per session plus N rows per event. The full ADK `Event` is dumped via `Event.model_dump_json(exclude_none=True)` into a single JSON column (`event_json`); a small number of indexed scalars (`session_id`, `invocation_id`, `author`, `timestamp`) are extracted for query performance. Reconstruction uses `Event.model_validate_json()`.
+Stores one row per session plus N rows per event. The full ADK `Event` is dumped via `event.model_dump(exclude_none=True, mode="json")` into a single JSON column (`event_data`); indexed scalars (`app_name`, `user_id`, `session_id`, `invocation_id`, `timestamp`) support filtering. Reconstruction uses `Event.model_validate()`.
 
 ### Memory store
 
@@ -28,14 +28,14 @@ Holds searchable memory entries extracted from completed sessions. The `SQLSpecM
 
 ### Artifact store
 
-Persists artifact **metadata** (filename, version, MIME type, `canonical_uri`, `custom_metadata`). The bytes live in a `sqlspec.storage` backend — `SQLSpecArtifactService` is constructed with `artifact_storage_uri="s3://..."` (or any URI the registry can resolve), and uses that for content reads/writes. Versioning is append-only starting from `0`.
+Persists artifact **metadata** when a deployment supplies a concrete metadata store. The metadata record tracks filename, version, MIME type, `canonical_uri`, and `custom_metadata`; bytes live in a `sqlspec.storage` backend via `artifact_storage_uri="s3://..."` or a registered storage alias. Versioning is append-only starting from `0`.
 
 ## Converters
 
 `sqlspec.extensions.adk.converters` bridges ADK's Pydantic models (`Session`, `Event`) and the `TypedDict` database records:
 
 - `session_to_record(session)` / `record_to_session(record, events)`
-- `event_to_record(event)` / `record_to_event(record)`
+- `event_to_record(event, app_name, user_id, session_id)` / `record_to_event(record)`
 - `filter_temp_state(state)` — strips `temp:`-prefixed keys so they never persist
 - `split_scoped_state(state)` / `merge_scoped_state(...)` — normalise the `app:`, `user:`, `temp:` prefixes ADK uses to scope state
 - `compute_update_marker(update_time)` — produces the same revision marker string ADK's built-in `StorageSession.get_update_marker()` emits, enabling optimistic-concurrency detection on `append_event`
@@ -44,7 +44,7 @@ Memory and artifact modules ship their own converter helpers (`sqlspec.extension
 
 ## Per-Adapter Store Implementations
 
-Production adapters ship concrete ADK stores from their `sqlspec.adapters.<adapter>.adk` package: `asyncpg`, `psycopg`, `psqlpy`, `cockroach_asyncpg`, `cockroach_psycopg`, `oracledb`, `sqlite`, `aiosqlite`, `duckdb`, `aiomysql`, `asyncmy`, `pymysql`, `mysqlconnector`, `spanner`, and `adbc`. Each contains both `<Adapter>ADKStore` (session/event) and `<Adapter>ADKMemoryStore` (memory).
+Production adapters ship concrete session/event and memory stores from their `sqlspec.adapters.<adapter>.adk` package: `asyncpg`, `psycopg`, `psqlpy`, `cockroach_asyncpg`, `cockroach_psycopg`, `oracledb`, `sqlite`, `aiosqlite`, `duckdb`, `aiomysql`, `asyncmy`, `pymysql`, `mysqlconnector`, `spanner`, and `adbc`. Each contains both `<Adapter>ADKStore` (session/event) and `<Adapter>ADKMemoryStore` (memory).
 
 Representative storage strategies:
 
@@ -58,17 +58,24 @@ Representative storage strategies:
 | `sqlite` / `aiosqlite` | `TEXT` with JSON1 functions | Local dev; small footprint |
 | `asyncmy` / `pymysql` / `mysqlconnector` | `JSON` | Uses MySQL's native JSON type |
 
-BigQuery and the `mock` adapter do **not** ship an ADK store; point those workloads at one of the adapters above.
+BigQuery and the `mock` adapter do **not** ship an ADK store. BigQuery was removed from the ADK backend surface because the batch-oriented job model does not fit ADK's low-latency transactional session/event writes. Use Spanner for a Google-managed operational backend or an OLTP backend such as PostgreSQL, MySQL, Oracle, SQLite, or CockroachDB.
 
 ## Schema Expectations
 
-Each store owns its DDL. The shipped migration under `sqlspec/extensions/litestar/migrations/0001_create_session_table.py` delegates to the adapter's store class for the `CREATE TABLE` — call `store._get_create_table_sql()` (or `ensure_tables()`) when bootstrapping outside of migrations. Table names are configurable via `extension_config["adk"]`:
+Each store owns its DDL. Call `ensure_tables()` or `create_tables()` when bootstrapping directly, or use SQLSpec migrations for managed deployments. Table names are configurable via `extension_config["adk"]`:
 
-- `session_table` (default `"adk_sessions"`)
-- `events_table` (default `"adk_events"`)
-- `memory_table` (default `"adk_memory_entries"`)
-- `artifact_table` (default `"adk_artifact_versions"`)
-- `owner_id_column` — optional DDL fragment (e.g. `"tenant_id INTEGER REFERENCES tenants(id)"`) for multi-tenant foreign keys
+- `session_table` (default `"adk_session"`)
+- `events_table` (default `"adk_event"`)
+- `app_state_table` (default `"adk_app_state"`)
+- `user_state_table` (default `"adk_user_state"`)
+- `metadata_table` (default `"adk_internal_metadata"`)
+- `memory_table` (default `"adk_memory"`)
+- `artifact_table` (default `"adk_artifact"`)
+- `owner_id_column` — optional DDL fragment (e.g. `"tenant_id INTEGER REFERENCES tenants(id)"`) for owner scoping when the store call path supplies owner IDs
+
+Migrations check that the selected adapter has the session and memory store classes before generating schema.
+
+The ADK 2 migration `0002_reset_adk_tables` is destructive: it drops legacy ADK session, event, state, metadata, and memory tables before recreating the 2.0 schema. Back up ADK data before applying it to an existing deployment.
 
 ## Litestar Handler Pattern
 
@@ -89,9 +96,9 @@ config = OracleAsyncConfig(
     connection_config={"dsn": "oracle+oracledb://app:app@oracle:1521/FREEPDB1"},
     extension_config={
         "adk": {
-            "session_table": "adk_sessions",
-            "events_table": "adk_events",
-            "memory_table": "adk_memory_entries",
+            "session_table": "adk_session",
+            "events_table": "adk_event",
+            "memory_table": "adk_memory",
         }
     },
 )
@@ -128,8 +135,8 @@ config = AsyncpgConfig(
     connection_config={"dsn": "postgresql://app:app@localhost/app"},
     extension_config={
         "adk": {
-            "session_table": "adk_sessions",
-            "events_table": "adk_events",
+            "session_table": "adk_session",
+            "events_table": "adk_event",
             "owner_id_column": "tenant_id INTEGER REFERENCES tenants(id)",
         }
     },
@@ -149,7 +156,7 @@ async def new_conversation(tenant_id: int, user_id: str) -> str:
     return session.id
 ```
 
-Synchronous adapters (`SqliteADKStore`, `DuckdbADKStore`, `OracleSyncADKStore`, etc.) use `SQLSpecSyncMemoryService` for the memory surface; session storage itself is async-only because the upstream ADK `BaseSessionService` interface is async.
+`SQLSpecSessionService` accepts async and sync stores. Sync store calls are bridged through SQLSpec's bounded async bridge because ADK's `BaseSessionService` interface is async. Memory has both `SQLSpecMemoryService` and `SQLSpecSyncMemoryService` surfaces.
 
 ## Public API Summary
 
@@ -161,6 +168,8 @@ Top-level exports from `sqlspec.extensions.adk`:
 - `BaseAsyncADKArtifactStore`, `BaseSyncADKArtifactStore`
 - `SessionRecord`, `EventRecord`, `MemoryRecord`, `ArtifactRecord`
 - `ADKConfig` (TypedDict describing `extension_config["adk"]`)
+
+`SQLSpecSessionService.append_event()` uses the store's `append_event_and_update_state()` as the durable write boundary. The event insert, session state update, and app/user scoped-state upserts succeed together. `temp:` state is stripped before persistence; `app:` and `user:` state live in separate tables and are merged back when sessions load.
 
 ## Cross References
 

--- a/skills/sqlspec/references/architecture.md
+++ b/skills/sqlspec/references/architecture.md
@@ -18,7 +18,7 @@ Raw SQL / Builder API / SQL File
     Driver Adapter (execute against database)
         |
         v
-    Result (rows, Arrow, scalar, rowcount)
+    Result (rows, Arrow, scalar, rows_affected)
 ```
 
 The `SQL` object is the single source of truth. All operations produce new `SQL` instances (immutability). The pipeline is single-pass: parse once, transform once, validate once.

--- a/skills/sqlspec/references/arrow.md
+++ b/skills/sqlspec/references/arrow.md
@@ -2,117 +2,117 @@
 
 ## Overview
 
-SQLSpec provides first-class Apache Arrow support for high-performance data transfer. Adapters that support ADBC or have native Arrow interfaces (DuckDB, BigQuery, Spanner) use zero-copy paths. All other adapters fall back to conversion from row dicts.
+SQLSpec exposes Arrow through `select_to_arrow()` / `fetch_to_arrow()` for export and the storage bridge methods for ingest. The export call returns `ArrowResult`, not a bare `pyarrow.Table`.
+
+Use Arrow for analytics, ETL, cross-database transfers, and native bulk ingest. Use row APIs for small request/response CRUD paths.
 
 ---
 
 ## select_to_arrow()
 
-Extract query results directly as a `pyarrow.Table`:
-
 ```python
-# Zero-copy on DuckDB, ADBC adapters
-arrow_table = await db_session.select_to_arrow(
+arrow_result = await db_session.select_to_arrow(
     "SELECT * FROM large_dataset WHERE region = $1",
-    [region],
+    region,
+    return_format="table",
+    native_only=False,
 )
 
-# arrow_table is a pyarrow.Table
-print(arrow_table.num_rows)
-print(arrow_table.schema)
+table = arrow_result.data
+print(arrow_result.rows_affected)
 ```
 
-### Performance Characteristics
+Supported `return_format` values:
 
-| Adapter | Path | Copy Overhead |
-| --- | --- | --- |
-| DuckDB | Native Arrow | Zero-copy |
-| ADBC | Native ADBC | Zero-copy |
-| BigQuery | Storage Read API | Zero-copy (streaming) |
-| Spanner | Native proto-Arrow | Near zero-copy |
-| AsyncPG | Conversion | Row-to-Arrow conversion |
-| Psycopg | Conversion | Row-to-Arrow conversion |
-| All others | Conversion | Row-to-Arrow conversion |
+| Value | Payload |
+| --- | --- |
+| `"table"` | Single `pyarrow.Table` |
+| `"batch"` | Single `pyarrow.RecordBatch` |
+| `"batches"` | Iterator of `RecordBatch` objects |
+| `"reader"` | `pyarrow.RecordBatchReader` |
+
+Use `batch_size=` for batch and reader shapes. Use `arrow_schema=` to cast or stabilize schema. Set `native_only=True` when conversion fallback would hide a performance or memory bug.
+
+### Native Export Paths
+
+| Adapter | Export behavior |
+| --- | --- |
+| `adbc` | ADBC native Arrow reader/table path |
+| `arrow_odbc` | ODBC Arrow batch reader path |
+| `duckdb` | DuckDB native Arrow result path |
+| `bigquery` | BigQuery native Arrow result path with configured job controls |
+| `spanner` | Spanner native Arrow conversion path |
+| `mssql_python` | SQL Server native Arrow/bulk-copy integration |
+| `oracledb` | Oracle Arrow export path |
+| Other adapters | Dict rows converted to Arrow unless `native_only=True` |
+
+`config.supports_arrow_streaming` advertises adapters with native streamed Arrow export behavior. It is a capability flag, not a separate public `select_arrow_stream()` method.
 
 ---
 
-## copy_from_arrow()
+## Row Streaming vs Arrow Results
 
-Bulk load data from an Arrow table into a database table:
+Use `select_stream()` for row-by-row processing. Use `select_to_arrow(return_format="reader")` for Arrow batch pipelines.
 
 ```python
-import pyarrow as pa
-
-# Create or obtain Arrow table
-arrow_table = pa.table({
-    "id": [1, 2, 3],
-    "name": ["Alice", "Bob", "Carol"],
-    "score": [95.5, 87.3, 92.1],
-})
-
-# Bulk load into database
-await db_session.copy_from_arrow(arrow_table, target_table="users")
+async with db_session.select_stream(
+    "SELECT id, payload FROM events ORDER BY id",
+    chunk_size=1_000,
+    native_only=True,
+) as stream:
+    async for row in stream:
+        await process_row(row)
 ```
 
-### Native Arrow Load Paths
-
-| Adapter | Method | Notes |
-| --- | --- | --- |
-| DuckDB | `INSERT INTO ... SELECT * FROM arrow_table` | In-process, zero-copy |
-| BigQuery | Load job with Arrow format | Streaming insert |
-| Spanner | Mutation-based insert | Batched |
-| ADBC | `adbc_ingest` | Native ADBC bulk load |
-
-For adapters without native Arrow support, SQLSpec converts the Arrow table to row-based parameters and uses `execute_many()`.
+Native row streaming and Arrow streaming are separate capabilities. An adapter can support one without the other.
 
 ---
 
-## record_batches() Iterator
+## Ingest From Arrow
 
-For streaming large result sets without loading everything into memory:
+Use `load_from_arrow()` for inbound Arrow data.
 
 ```python
-async for batch in db_session.record_batches(
-    "SELECT * FROM very_large_table",
-    batch_size=10_000,
-):
-    # batch is a pyarrow.RecordBatch
-    process_batch(batch)
+job = await target_session.load_from_arrow(
+    "refined_analytics",
+    arrow_result,
+    overwrite=False,
+)
+print(job.telemetry["rows_processed"])
 ```
+
+Native ingest routes through adapter-specific primitives: PostgreSQL `COPY`, DuckDB registration plus `INSERT ... SELECT`, ADBC `adbc_ingest`, Oracle direct path load when available, BigQuery load jobs or Storage Write API, Spanner mutations or Batch Write API, SQL Server `bulkcopy()`, `arrow_odbc` `bulk_insert_arrow`, SQLite transactional `executemany`, and MySQL `executemany` or gated `LOAD DATA LOCAL INFILE`.
+
+See [bulk-ingest.md](bulk-ingest.md) for adapter gates and caveats.
 
 ---
 
 ## Cross-Database Arrow Pipeline
 
-A common pattern is extracting data from one database and loading into another using Arrow as the interchange format:
-
 ```python
-# Extract from DuckDB (zero-copy)
-arrow_table = duckdb_session.select_to_arrow(
-    "SELECT * FROM local_analytics WHERE date > $1",
-    [cutoff_date],
+source_result = await source_session.select_to_arrow(
+    "SELECT * FROM events WHERE updated_at > $1",
+    last_sync,
+    return_format="table",
 )
 
-# Load into BigQuery (native Arrow load)
-await bq_session.copy_from_arrow(arrow_table, target_table="refined_analytics")
+job = await target_session.load_from_arrow("events", source_result)
 ```
 
-### Two-Path Strategy
+Guidance:
 
-1. **Native Arrow Path** (ADBC, DuckDB, BigQuery, Spanner):
-   - Zero-copy data transfer, 5-10x faster than row-based.
-   - Uses ADBC loaders and native driver Arrow support.
-2. **Conversion Path** (all other adapters):
-   - Dict results converted to Arrow via `pyarrow.Table.from_pylist()`.
-   - Arrow tables converted to row parameters via `.to_pylist()` for loading.
+- Keep `ArrowResult` intact when passing between SQLSpec sessions.
+- Use `return_format="reader"` for large exports that downstream code consumes in batches.
+- Use `native_only=True` in tests for critical native paths so a conversion fallback cannot pass unnoticed.
+- Use `load_from_records()` when data originates as Python records; it normalizes through Arrow and then uses the same ingest surface.
 
 ---
 
-## Arrow Type Mapping
+## Type Mapping
 
-SQLSpec maps database types to Arrow types automatically:
+SQLSpec maps database values to Arrow through adapter-native metadata when available, otherwise through Python dict-row conversion.
 
-| SQL Type | Arrow Type |
+| SQL Type | Typical Arrow Type |
 | --- | --- |
 | INTEGER / BIGINT | `int64` |
 | REAL / DOUBLE | `float64` |
@@ -122,5 +122,5 @@ SQLSpec maps database types to Arrow types automatically:
 | TIMESTAMP | `timestamp[us]` |
 | DECIMAL | `decimal128` |
 | BLOB / BYTEA | `binary` |
-| JSON / JSONB | `utf8` (serialized) |
-| UUID | `utf8` |
+| JSON / JSONB | serialized string or adapter-native JSON representation |
+| UUID | string unless adapter/native schema preserves UUID semantics |

--- a/skills/sqlspec/references/bulk-ingest.md
+++ b/skills/sqlspec/references/bulk-ingest.md
@@ -1,0 +1,77 @@
+# SQLSpec Native Bulk Ingest
+
+## Overview
+
+SQLSpec `v0.51.0` exposes native bulk ingest through three storage bridge methods:
+
+- `load_from_arrow(table, source, *, overwrite=False)` -- load an Arrow table or coercible Arrow source.
+- `load_from_storage(table, source, *, file_format, overwrite=False)` -- load a local path or cloud URI.
+- `load_from_records(table, records, *, columns=None, overwrite=False)` -- load in-memory rows.
+
+All three return `StorageBridgeJob`; inspect `job.telemetry["rows_processed"]`, `bytes_processed`, and adapter-specific `extra` metadata.
+
+---
+
+## load_from_records()
+
+Use `load_from_records()` for Python records. Mapping rows infer columns from keys; positional rows require `columns=`.
+
+```python
+await driver.load_from_records(
+    "orders",
+    [{"id": 1, "total": 9.99}, {"id": 2, "total": 4.50}],
+)
+
+await driver.load_from_records(
+    "orders",
+    [(3, 1.0), (4, 2.0)],
+    columns=["id", "total"],
+)
+```
+
+Records normalize to Arrow and route through the adapter's `load_from_arrow()` path. Empty input, mismatched mapping keys, and positional width mismatches raise `ImproperConfigurationError`.
+
+---
+
+## Adapter Matrix
+
+| Adapter | Native ingest path | Gate / caveat |
+| --- | --- | --- |
+| `asyncpg` | `COPY` via `copy_records_to_table` | Always on; atomic with exact row counts |
+| `psycopg` sync/async | `COPY` streaming `write_row` | Always on; atomic with exact row counts |
+| `psqlpy` | Binary `COPY` with `INSERT` fallback | Always on |
+| `adbc` | `adbc_ingest` | Driver-dependent; Flight SQL may fall back per row |
+| `duckdb` | register Arrow table, then `INSERT ... SELECT` | Single connection transaction |
+| `sqlite` / `aiosqlite` | `executemany` in one `BEGIN IMMEDIATE` | Atomic when the driver owns the transaction |
+| `oracledb` | Direct path load in Thin mode; `executemany` fallback | Set `enable_direct_path_load=False` to force fallback |
+| `pymysql`, `asyncmy`, `aiomysql`, `mysqlconnector` | `executemany`; opt-in `LOAD DATA LOCAL INFILE` | Requires feature and connection local-infile gate |
+| `bigquery` | Parquet load job; optional Storage Write API for appends | `enable_storage_write_api`; `overwrite=True` uses Parquet `WRITE_TRUNCATE` |
+| `spanner` | `insert_or_update` mutations; optional Batch Write API | `enable_batch_write_api`; Batch Write commits groups independently |
+| `mssql_python` | `cursor.bulkcopy()` | Driver-managed |
+| `arrow_odbc` | `bulk_insert_arrow` | Driver-managed |
+
+---
+
+## Security Gates
+
+MySQL `LOAD DATA LOCAL INFILE` reads client-side files. Enable it only when the server, connection, and SQLSpec adapter feature are all intentionally configured:
+
+- `pymysql`, `aiomysql`: `connection_config={"local_infile": True}` plus `driver_features={"enable_local_infile_bulk_load": True}`.
+- `asyncmy`: `allow_local_infile=True` is required before `local_infile=True` is honored.
+- `mysqlconnector`: `connection_config={"allow_local_infile": True}` plus the feature flag. Honor `allow_local_infile_in_path` when set.
+
+Oracle direct path load is the default in Thin mode when the connection exposes the Direct Path Load API. Thick-mode or unsupported connections fall back to `executemany()`.
+
+BigQuery Storage Write API is append-only in this surface. `overwrite=True` uses a Parquet load job instead.
+
+Spanner Batch Write API uses independently committed mutation groups. Treat it as high-throughput idempotent upsert behavior, not as a single transaction.
+
+---
+
+## Usage Rules
+
+- Use `load_from_records()` for in-memory data instead of hand-written `execute_many()` loops when ingest volume matters.
+- Use `load_from_arrow()` when the upstream step already produced Arrow.
+- Use `load_from_storage()` for staged files and cloud URIs. BigQuery requires `gs://` staging for load paths.
+- Check `config.storage_capabilities()` before building generic ingest tooling.
+- Keep adapter gates in configuration. Do not pass invented per-call flags to `load_from_arrow()`.

--- a/skills/sqlspec/references/data-dictionary.md
+++ b/skills/sqlspec/references/data-dictionary.md
@@ -1,6 +1,6 @@
 # SQLSpec Data Dictionary
 
-`sqlspec.data_dictionary` is the introspection layer that exposes `information_schema`-style metadata — table lists, column definitions, indexes, foreign keys, database version, feature flags — uniformly across every supported dialect. It is what the migration tracker uses to decide whether `ddl_migrations` needs schema upgrades, and what adapter-specific code uses to pick an optimal column type for a logical category (e.g. "give me the best JSON type this Postgres version can handle").
+`sqlspec.data_dictionary` is the introspection layer that exposes `information_schema`-style metadata -- table lists, column definitions, indexes, foreign keys, database version, feature flags, and native statistics where supported. It is what the migration tracker uses to decide whether `ddl_migrations` needs schema upgrades, and what adapter-specific code uses to pick an optimal column type for a logical category (e.g. "give me the best JSON type this Postgres version can handle").
 
 ## What It Is
 
@@ -17,7 +17,8 @@ Top-level exports in `sqlspec.data_dictionary.__init__`:
 
 - `DataDictionaryLoader`, `get_data_dictionary_loader()` — singleton that lazy-loads the per-dialect SQL queries from `sqlspec/data_dictionary/sql/<dialect>/*.sql`.
 - `get_dialect_config(dialect)`, `list_registered_dialects()`, `register_dialect(config)`, `normalize_dialect_name(dialect)` — the dialect registry.
-- `DialectConfig`, `FeatureFlags`, `FeatureVersions` — the static-config types in `sqlspec/data_dictionary/_types.py`.
+- `DialectConfig`, `FeatureFlags`, `FeatureVersions` — static-config types in `sqlspec/data_dictionary/_types.py`.
+- `TableMetadata`, `ColumnMetadata`, `IndexMetadata`, `ForeignKeyMetadata`, `TableStatisticsMetadata` — runtime metadata types exported from `sqlspec.data_dictionary`.
 
 `DialectConfig` fields (see `sqlspec/data_dictionary/_types.py`):
 
@@ -36,16 +37,17 @@ config = DialectConfig(
 
 `FeatureFlags` is a `TypedDict` with keys like `supports_arrays`, `supports_clustering`, `supports_cte`, `supports_json`, `supports_returning`, `supports_upsert`, `supports_uuid`, `supports_window_functions`. `FeatureVersions` maps a subset of those to `VersionInfo(major, minor, patch)` minimums.
 
-Runtime metadata types live in `sqlspec.typing` and are `TypedDict`s:
+Runtime metadata types live in `sqlspec.data_dictionary`:
 
 - `TableMetadata` — `schema_name`, `table_name`, `table_type`, `table_catalog`.
 - `ColumnMetadata` — `column_name`, `data_type`, `is_nullable`, `column_default`, `ordinal_position`, `max_length`, `numeric_precision`, `numeric_scale`, `is_primary`, `is_unique`, `extra`.
 - `IndexMetadata` — `index_name`, `columns`, `is_unique`, `is_primary`.
 - `ForeignKeyMetadata` — source/target columns and schemas.
+- `TableStatisticsMetadata` — `catalog_name`, `schema_name`, `table_name`, optional `column_name`, `statistic_key`, `statistic_name`, `statistic_value`, `is_approximate`.
 
 ## Dialect Coverage
 
-Eight dialect modules register a `DialectConfig` when imported (`sqlspec/data_dictionary/dialects/__init__.py`):
+Dialect modules register a `DialectConfig` when imported (`sqlspec/data_dictionary/dialects/__init__.py`):
 
 | Dialect module | Exported config |
 | --- | --- |
@@ -53,6 +55,7 @@ Eight dialect modules register a `DialectConfig` when imported (`sqlspec/data_di
 | `cockroachdb.py` | `COCKROACHDB_CONFIG` |
 | `duckdb.py` | `DUCKDB_CONFIG` |
 | `mysql.py` | `MYSQL_CONFIG` |
+| `mssql.py` | `MSSQL_CONFIG` |
 | `oracle.py` | `ORACLE_CONFIG` |
 | `postgres.py` | `POSTGRES_CONFIG` |
 | `spanner.py` | `SPANNER_CONFIG` |
@@ -96,6 +99,8 @@ Available driver-side methods (async signatures shown; sync drivers expose the s
 - `await driver.data_dictionary.get_columns(driver, table=None, schema=None)` → `list[ColumnMetadata]`
 - `await driver.data_dictionary.get_indexes(driver, table=None, schema=None)` → `list[IndexMetadata]`
 - `await driver.data_dictionary.get_foreign_keys(driver, table=None, schema=None)` → `list[ForeignKeyMetadata]`
+
+ADBC adds an adapter-specific `get_statistics(driver, table, schema=None)` method that wraps the native `adbc_get_statistics` API and returns `list[TableStatisticsMetadata]`. It is separate from the shared data dictionary surface because SQLSpec does not define a portable SQL statistics contract. Unsupported ADBC drivers raise `OperationalError`; PostgreSQL provides approximate native statistics, SQLite and DuckDB currently raise, Flight SQL behavior is server-dependent, and BigQuery is unverified.
 
 ### Sync
 

--- a/skills/sqlspec/references/driver_api.md
+++ b/skills/sqlspec/references/driver_api.md
@@ -2,90 +2,131 @@
 
 ## Overview
 
-All database interactions go through driver adapters. Async adapters extend `AsyncDriverAdapterBase`, sync adapters extend `SyncDriverAdapterBase`. Both expose the same method surface with sync/async variants.
+All database interactions go through driver adapters. Async adapters extend `AsyncDriverAdapterBase`; sync adapters extend `SyncDriverAdapterBase`. The public method surface is parallel: async drivers use `await`, sync drivers do not.
+
+Use the current method names. `select_many()` and `copy_from_arrow()` are not public SQLSpec APIs in `v0.51.0`.
+
+Bind normal query parameters as variadic positional arguments. Use `await db_session.select("... WHERE id = $1", user_id, schema_type=User)`, not `await db_session.select(..., [user_id], ...)`. Keep list or tuple containers for real batch/data payloads such as `execute_many()` parameter sets or `load_from_records()` rows.
 
 ---
 
 ## Query Methods
 
-### select_value() -- Single Scalar
+### select() / fetch() -- Multiple Rows
 
-Returns a single scalar value from the first column of the first row:
+Return a list of rows. `fetch()` is an alias for users coming from asyncpg-style naming.
 
 ```python
-count = await db_session.select_value("SELECT COUNT(*) FROM users")
-# Returns: 42
-
-name = await db_session.select_value(
-    "SELECT name FROM users WHERE id = $1", [user_id]
+users = await db_session.select(
+    "SELECT * FROM users WHERE active = $1",
+    True,
+    schema_type=User,
 )
-# Returns: "Alice"
 ```
+
+When `schema_type` is omitted, rows are dicts. `schema_type` supports Pydantic models, dataclasses, msgspec structs, attrs classes, and TypedDicts.
 
 ### select_one() -- Single Row (Strict)
 
-Returns exactly one row. Raises `NotFoundError` if no rows, `MultipleResultsError` if more than one:
+Return exactly one row. SQLSpec maps the no-row case to `NotFoundError`; multiple rows remain a `ValueError` from result cardinality validation.
 
 ```python
 user = await db_session.select_one(
     "SELECT * FROM users WHERE id = $1",
-    [user_id],
+    user_id,
     schema_type=User,
 )
 ```
 
 ### select_one_or_none() -- Single Row (Optional)
 
-Returns one row or `None`. Raises `MultipleResultsError` if more than one:
+Return one row or `None`. More than one row raises `ValueError`.
 
 ```python
 user = await db_session.select_one_or_none(
     "SELECT * FROM users WHERE email = $1",
-    [email],
+    email,
     schema_type=User,
 )
-if user is None:
-    # Handle not found
-    ...
 ```
 
-### select_many() -- Multiple Rows
+### select_value() / select_value_or_none() -- Scalar Values
 
-Returns a list of rows:
+Use `value_type=` to narrow and coerce the returned scalar.
 
 ```python
-users = await db_session.select_many(
-    "SELECT * FROM users WHERE active = $1",
-    [True],
-    schema_type=User,
+count = await db_session.select_value(
+    "SELECT COUNT(*) FROM users WHERE active = $1",
+    True,
+    value_type=int,
 )
 ```
 
 ### select_with_total() -- Pagination
 
-Returns rows plus total count for pagination. Executes a windowed count query:
+Return rows plus total count for pagination. Use `count_with_window=True` only when the target dialect and query shape support the window-count path.
 
 ```python
 users, total = await db_session.select_with_total(
     "SELECT * FROM users WHERE active = $1 ORDER BY name LIMIT $2 OFFSET $3",
-    [True, 20, 40],
+    True,
+    20,
+    40,
     schema_type=User,
 )
-# total = 156 (total matching rows, ignoring LIMIT/OFFSET)
-# users = [...] (up to 20 rows)
 ```
 
-### select_to_arrow() -- Arrow Result
+### select_stream() / fetch_stream() -- Row Streaming
 
-Returns an Arrow table. Zero-copy on ADBC and DuckDB adapters:
+Return a context-managed row stream fetched in chunks. Use `native_only=True` when eager fallback would be incorrect for memory use.
 
 ```python
-arrow_table = await db_session.select_to_arrow(
-    "SELECT * FROM large_dataset WHERE region = $1",
-    [region],
-)
-# arrow_table is a pyarrow.Table
+async with db_session.select_stream(
+    "SELECT id, payload FROM events ORDER BY id",
+    chunk_size=1_000,
+    native_only=True,
+) as stream:
+    async for row in stream:
+        await process(row)
 ```
+
+Native row streaming support is discoverable via `config.supports_native_row_streaming`.
+
+Native paths:
+
+- `psycopg` / `cockroach_psycopg`: server-side named cursors.
+- `asyncpg` / `cockroach_asyncpg`: cursors inside a stream-owned transaction.
+- `pymysql`, `aiomysql`, `asyncmy`: `SSCursor`.
+- `mysqlconnector`: unbuffered cursors.
+- `sqlite`, `aiosqlite`, `oracledb`: chunked `fetchmany()`.
+- `psqlpy`: server-side cursor with `array_size`.
+- `bigquery`: page-wise result iteration.
+
+Eager fallback only: `adbc`, `duckdb`, `mssql_python`, `arrow_odbc`, and `spanner`.
+
+Lifetime rules:
+
+- Close or exhaust the stream before issuing another statement on the same connection.
+- PostgreSQL-family streams open their own transaction or savepoint and close it when the stream closes.
+- MySQL unbuffered cursors drain remaining rows when closed mid-iteration.
+- BigQuery `page_size` is advisory.
+- Oracle streams return raw driver values for LOB columns.
+- If iteration raises on PostgreSQL drivers, roll back before reusing the connection.
+
+### select_to_arrow() / fetch_to_arrow() -- Arrow Result
+
+Return an `ArrowResult`, not a bare `pyarrow.Table`. Use `return_format=` to choose `table`, `batch`, `batches`, or `reader`.
+
+```python
+arrow_result = await db_session.select_to_arrow(
+    "SELECT * FROM large_dataset WHERE region = $1",
+    region,
+    return_format="reader",
+    batch_size=10_000,
+)
+```
+
+Adapters without native Arrow export use dict-to-Arrow conversion. Add `native_only=True` only when the selected adapter has a native Arrow override and fallback would hide a performance or memory bug.
 
 ---
 
@@ -93,20 +134,21 @@ arrow_table = await db_session.select_to_arrow(
 
 ### execute() -- Single Statement
 
-Execute a DML statement (INSERT, UPDATE, DELETE) and return result with rowcount:
+Execute a statement and return `SQLResult`.
 
 ```python
 result = await db_session.execute(
     "INSERT INTO users (name, email) VALUES ($1, $2) RETURNING id",
-    ["Alice", "alice@example.com"],
+    "Alice",
+    "alice@example.com",
 )
-print(result.rowcount)        # 1
-print(result.last_insert_id)  # UUID or int
+print(result.rows_affected)
+print(result.last_inserted_id)
 ```
 
 ### execute_many() -- Batch DML
 
-Execute a statement with multiple parameter sets:
+Execute one statement with multiple parameter sets. Use tuple/list parameters for positional styles and mapping parameters for named styles.
 
 ```python
 result = await db_session.execute_many(
@@ -114,11 +156,56 @@ result = await db_session.execute_many(
     [
         ("Alice", "alice@example.com"),
         ("Bob", "bob@example.com"),
-        ("Carol", "carol@example.com"),
     ],
 )
-print(result.rowcount)  # 3
+print(result.rows_affected)
 ```
+
+For high-volume ingest, prefer `load_from_records()` or `load_from_arrow()` when the adapter supports native ingest.
+
+---
+
+## Storage Bridge Methods
+
+### load_from_arrow()
+
+Load an Arrow table or coercible Arrow source into a target table through the adapter's native ingest path.
+
+```python
+job = await db_session.load_from_arrow("orders", arrow_result, overwrite=False)
+print(job.telemetry["rows_processed"])
+```
+
+### load_from_storage()
+
+Load a staged artifact, local path, or cloud URI into a target table.
+
+```python
+job = await db_session.load_from_storage(
+    "orders",
+    "gs://bucket/orders.parquet",
+    file_format="parquet",
+)
+```
+
+### load_from_records()
+
+Normalize in-memory mapping or positional records into Arrow, then route through `load_from_arrow()`.
+
+```python
+await db_session.load_from_records(
+    "orders",
+    [{"id": 1, "total": 9.99}, {"id": 2, "total": 4.50}],
+)
+
+await db_session.load_from_records(
+    "orders",
+    [(3, 1.0), (4, 2.0)],
+    columns=["id", "total"],
+)
+```
+
+Empty records, mismatched mapping keys, and positional width mismatches raise `ImproperConfigurationError`.
 
 ---
 
@@ -126,86 +213,44 @@ print(result.rowcount)  # 3
 
 ### begin() / commit() / rollback()
 
-Explicit transaction control:
+Use explicit transaction control only when a higher-level session or framework commit mode is not managing the transaction.
 
 ```python
 await db_session.begin()
 try:
-    await db_session.execute("UPDATE accounts SET balance = balance - $1 WHERE id = $2", [100, from_id])
-    await db_session.execute("UPDATE accounts SET balance = balance + $1 WHERE id = $2", [100, to_id])
+    await db_session.execute("UPDATE accounts SET balance = balance - $1 WHERE id = $2", 100, from_id)
+    await db_session.execute("UPDATE accounts SET balance = balance + $1 WHERE id = $2", 100, to_id)
     await db_session.commit()
 except Exception:
     await db_session.rollback()
     raise
 ```
 
-### session() Context Manager
+### provide_session() Context Manager
 
-Preferred pattern for transaction scoping:
-
-```python
-async with db_session.session() as session:
-    await session.execute("INSERT INTO logs (msg) VALUES ($1)", ["started"])
-    await session.execute("UPDATE jobs SET status = $1 WHERE id = $2", ["running", job_id])
-    # Auto-commits on successful exit, auto-rolls-back on exception
-```
-
----
-
-## Schema Mapping with schema_type
-
-All select methods accept a `schema_type` parameter for automatic row mapping to Pydantic models or msgspec structs:
+Use `SQLSpec.provide_session(config)` or `config.provide_session()` for lifecycle scoping. Framework integrations usually provide this per request.
 
 ```python
-from pydantic import BaseModel
-
-class User(BaseModel):
-    id: int
-    name: str
-    email: str
-
-# Pydantic model mapping
-user = await db_session.select_one(
-    "SELECT id, name, email FROM users WHERE id = $1",
-    [user_id],
-    schema_type=User,
-)
-# user is a User instance
+async with config.provide_session() as session:
+    await session.execute("INSERT INTO logs (msg) VALUES ($1)", "started")
 ```
-
-```python
-import msgspec
-
-class User(msgspec.Struct):
-    id: int
-    name: str
-    email: str
-
-# msgspec struct mapping (faster serialization)
-user = await db_session.select_one(
-    "SELECT id, name, email FROM users WHERE id = $1",
-    [user_id],
-    schema_type=User,
-)
-```
-
-When `schema_type` is omitted, rows are returned as dicts.
 
 ---
 
 ## Method Summary
 
-| Method | Returns | Raises |
+| Method | Returns | Notes |
 | --- | --- | --- |
-| `select_value(sql, params)` | `Any` (scalar) | `NotFoundError` if no rows |
-| `select_one(sql, params, schema_type=)` | `T` or `dict` | `NotFoundError`, `MultipleResultsError` |
-| `select_one_or_none(sql, params, schema_type=)` | `T \| None` | `MultipleResultsError` |
-| `select_many(sql, params, schema_type=)` | `list[T]` or `list[dict]` | -- |
-| `select_with_total(sql, params, schema_type=)` | `tuple[list[T], int]` | -- |
-| `select_to_arrow(sql, params)` | `pyarrow.Table` | -- |
-| `execute(sql, params)` | `ExecutionResult` | adapter-specific |
-| `execute_many(sql, params_list)` | `ExecutionResult` | adapter-specific |
-| `begin()` | `None` | -- |
-| `commit()` | `None` | -- |
-| `rollback()` | `None` | -- |
-| `session()` | context manager | -- |
+| `select()` / `fetch()` | `list[T]` or `list[dict]` | Multiple rows |
+| `select_one()` / `fetch_one()` | `T` or `dict` | No row becomes `NotFoundError`; multiple rows raise `ValueError` |
+| `select_one_or_none()` / `fetch_one_or_none()` | `T \| dict \| None` | Optional row |
+| `select_value()` / `fetch_value()` | Scalar | Optional `value_type=` coercion |
+| `select_value_or_none()` / `fetch_value_or_none()` | Scalar or `None` | Optional scalar |
+| `select_with_total()` / `fetch_with_total()` | `tuple[list[T], int]` | Pagination |
+| `select_stream()` / `fetch_stream()` | `SyncRowStream` / `AsyncRowStream` | Context-managed chunk stream |
+| `select_to_arrow()` / `fetch_to_arrow()` | `ArrowResult` | `return_format="table" \| "batch" \| "batches" \| "reader"` |
+| `execute()` | `SQLResult` | Check `rows_affected`, `last_inserted_id`, `metadata` |
+| `execute_many()` | `SQLResult` | Batch parameters |
+| `load_from_arrow()` | `StorageBridgeJob` | Native ingest where supported |
+| `load_from_storage()` | `StorageBridgeJob` | Staged files/cloud URIs |
+| `load_from_records()` | `StorageBridgeJob` | Records normalized through Arrow |

--- a/skills/sqlspec/references/extensions.md
+++ b/skills/sqlspec/references/extensions.md
@@ -39,16 +39,17 @@ from litestar import get, post
 
 @get("/users")
 async def list_users(db_session: AsyncpgDriver) -> list[dict]:
-    result = await db_session.select_many("SELECT * FROM users")
+    result = await db_session.select("SELECT * FROM users")
     return result
 
 @post("/users")
 async def create_user(db_session: AsyncpgDriver, data: UserCreate) -> dict:
     result = await db_session.execute(
         "INSERT INTO users (name, email) VALUES ($1, $2) RETURNING id",
-        [data.name, data.email],
+        data.name,
+        data.email,
     )
-    return {"id": result.last_insert_id}
+    return {"id": result.last_inserted_id}
 ```
 
 ### Session Store Integration
@@ -129,7 +130,7 @@ db_ext = SQLSpecPlugin(sqlspec=spec, app=app)
 @app.get("/users")
 async def list_users(request: Request):
     db_session = db_ext.get_session(request)
-    result = await db_session.select_many("SELECT * FROM users")
+    result = await db_session.select("SELECT * FROM users")
     return result
 ```
 
@@ -172,7 +173,7 @@ All adapters wrap exceptions using `wrap_exceptions` referencing static mappings
 - `AdapterError`: Generic connectivity or execution issues.
 - `IntegrityError`: Constraint and uniqueness violations.
 - `NotFoundError`: Expected row not found.
-- `MultipleResultsError`: Expected single row but got multiple.
+- `ValueError`: `select_one()` and `select_one_or_none()` received multiple rows.
 
 ### Two-Tier Event Reporting
 

--- a/skills/sqlspec/references/fastapi-integration.md
+++ b/skills/sqlspec/references/fastapi-integration.md
@@ -144,7 +144,7 @@ SessionDep = Annotated[AsyncpgDriver, Depends(db_plugin.provide_session())]
 
 @app.get("/orders/{order_id}")
 async def get_order(order_id: int, db: SessionDep) -> dict[str, Any]:
-    rows = await db.select("SELECT * FROM orders WHERE id = $1", [order_id])
+    rows = await db.select("SELECT * FROM orders WHERE id = $1", order_id)
     return {"order": rows[0] if rows else None}
 ```
 
@@ -454,14 +454,16 @@ async def create_order(payload: dict[str, Any], db: SessionDep) -> dict[str, Any
         raise HTTPException(status_code=422, detail="customer_id and amount required")
     result = await db.execute(
         "INSERT INTO orders (customer_id, status, amount) VALUES ($1, $2, $3) RETURNING id",
-        [payload["customer_id"], "pending", payload["amount"]],
+        payload["customer_id"],
+        "pending",
+        payload["amount"],
     )
     return {"id": result.one()["id"]}
 
 
 @app.get("/orders/{order_id}")
 async def get_order(order_id: int, db: SessionDep) -> dict[str, Any]:
-    rows = await db.select("SELECT * FROM orders WHERE id = $1", [order_id])
+    rows = await db.select("SELECT * FROM orders WHERE id = $1", order_id)
     if not rows:
         raise HTTPException(status_code=404, detail="order not found")
     return {"order": rows[0]}

--- a/skills/sqlspec/references/flask-integration.md
+++ b/skills/sqlspec/references/flask-integration.md
@@ -208,7 +208,9 @@ def create_order() -> tuple[dict, int]:
     db: SqliteDriver = plugin.get_session()
     result = db.execute(
         "INSERT INTO orders (customer_id, status, amount) VALUES (?, ?, ?) RETURNING id",
-        [payload["customer_id"], "pending", payload["amount"]],
+        payload["customer_id"],
+        "pending",
+        payload["amount"],
     )
     return {"id": result.one()["id"]}, 201
 
@@ -396,7 +398,9 @@ def create_app() -> Flask:
         db: SqliteDriver = plugin.get_session()
         result = db.execute(
             "INSERT INTO orders (customer_id, status, amount) VALUES (?, ?, ?) RETURNING id",
-            [payload["customer_id"], "pending", payload["amount"]],
+            payload["customer_id"],
+            "pending",
+            payload["amount"],
         )
         return {"id": result.one()["id"]}, 201
 

--- a/skills/sqlspec/references/loader.md
+++ b/skills/sqlspec/references/loader.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`SQLFileLoader` loads SQL statements from external files, supporting metadata directives, multiple search paths, and content caching with checksums.
+`SQLFileLoader` loads SQL statements from external files, supporting metadata directives, declared parameter annotations, multiple search paths, and content caching with checksums.
 
 ---
 
@@ -16,7 +16,7 @@ loader.load_sql("./sql", "./sql/queries")
 
 # Load a named query
 stmt = loader.get_sql("get-user-by-id")
-result = await db_session.select_one(stmt, [user_id], schema_type=User)
+result = await db_session.select_one(stmt, user_id, schema_type=User)
 ```
 
 ---
@@ -40,6 +40,7 @@ WHERE id = $1
 | --- | --- | --- |
 | `-- name:` | Yes | Unique identifier for the query |
 | `-- dialect:` | No | Source dialect for sqlglot parsing |
+| `-- param:` | No | Declared parameter metadata and validation |
 | `-- description:` | No | Human-readable description |
 | `-- result:` | No | Expected result type hint (`one`, `many`, `value`, `affected`) |
 
@@ -58,6 +59,38 @@ SELECT COUNT(*) FROM users
 -- dialect: postgres
 SELECT * FROM users WHERE email = $1
 ```
+
+---
+
+## Declared Parameters
+
+Use `-- param:` lines in the leading comment block for named SQL that crosses service boundaries:
+
+```sql
+-- name: get-team-by-name
+-- param: name str  The team name to look up
+SELECT id, name FROM teams WHERE name = :name
+
+-- name: list-teams
+-- param: name str?  Optional team name filter
+SELECT id, name FROM teams
+WHERE (:name IS NULL OR name = :name)
+ORDER BY id
+```
+
+Grammar: `-- param: <name> <type> [description]`. Append `?` to the type or end the description with `(optional)` to mark a named parameter optional.
+
+Behavior:
+
+- No `-- param:` lines means no declaration validation and no behavior change.
+- Required declarations must be supplied at execution time.
+- Missing optional named declarations bind `None`; the SQL must express the intended nullable condition.
+- Declared names are cross-checked against actual placeholders at load time.
+- Type strings from the allowlist are checked at execution time; unresolved type strings are documentation-only.
+- Extra parameters are allowed because filters may add `limit`, `offset`, and related parameters.
+- Malformed `-- param:` lines warn and are skipped by default. Pass `strict_parameter_annotations=True` to `SQLFileLoader` to make malformed annotations fail.
+
+Introspect declarations with `spec.get_query_parameters(name)` or `spec.get_sql(name).declared_parameters`.
 
 ---
 
@@ -133,9 +166,9 @@ loader.load_sql("./sql")
 
 # Load and execute
 stmt = loader.get_sql("list-active-users")
-users = await db_session.select_many(stmt, schema_type=User)
+users = await db_session.select(stmt, schema_type=User)
 
 # Load with parameter override
 stmt = loader.get_sql("get-user-by-id")
-user = await db_session.select_one(stmt, [user_id], schema_type=User)
+user = await db_session.select_one(stmt, user_id, schema_type=User)
 ```

--- a/skills/sqlspec/references/patterns.md
+++ b/skills/sqlspec/references/patterns.md
@@ -5,7 +5,7 @@
 `SQLSpecAsyncService` ships upstream in `sqlspec.service`. Use it as the base class for app services that wrap an async driver with helpers like `paginate`, `get_one`, `exists`, and `begin_transaction`.
 
 ```python
-from sqlspec.core.filters import OffsetPagination
+from sqlspec.core.filters import LimitOffsetFilter, OffsetPagination
 from sqlspec.service import SQLSpecAsyncService
 
 
@@ -13,9 +13,8 @@ class UserService(SQLSpecAsyncService):
     async def list_users(self, page: int = 1, page_size: int = 20) -> OffsetPagination[User]:
         return await self.paginate(
             "SELECT * FROM users ORDER BY created_at DESC",
+            LimitOffsetFilter(limit=page_size, offset=page_size * (page - 1)),
             schema_type=User,
-            page=page,
-            page_size=page_size,
         )
 
     async def get_user(self, user_id: str) -> User:
@@ -35,11 +34,13 @@ class UserService(SQLSpecAsyncService):
         async with self.begin_transaction() as tx:
             await tx.execute(
                 "UPDATE accounts SET balance = balance - $1 WHERE id = $2",
-                [amount, from_id],
+                amount,
+                from_id,
             )
             await tx.execute(
                 "UPDATE accounts SET balance = balance + $1 WHERE id = $2",
-                [amount, to_id],
+                amount,
+                to_id,
             )
 ```
 
@@ -71,7 +72,7 @@ result = await db_session.execute_many(
     "INSERT INTO users (name, email) VALUES ($1, $2)",
     users,
 )
-print(f"Inserted {result.rowcount} rows")
+print(f"Inserted {result.rows_affected} rows")
 ```
 
 ### Batch with Dicts
@@ -128,7 +129,7 @@ query = (
 )
 
 stmt = query.to_statement()
-rows = await db_session.select_many(stmt, schema_type=DeptSummary)
+rows = await db_session.select(stmt, schema_type=DeptSummary)
 ```
 
 ---

--- a/skills/sqlspec/references/performance.md
+++ b/skills/sqlspec/references/performance.md
@@ -1,0 +1,114 @@
+# SQLSpec Performance & Cloud Controls
+
+## Overview
+
+SQLSpec keeps performance controls explicit. Configure them through adapter `connection_config`, `driver_features`, `statement_config`, or the documented session providers. Do not invent new driver methods for cloud job/session control.
+
+---
+
+## Bounded Async Bridge
+
+`sqlspec.utils.sync_tools.async_()` wraps blocking callables for async code. In `v0.51.0`, SQLSpec uses a process-local managed `ThreadPoolExecutor` capped by default.
+
+Use an explicit executor when the call site owns the pool:
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+
+from sqlspec.utils.sync_tools import async_
+
+executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="sqlspec")
+run_query = async_(blocking_query, executor=executor)
+result = await run_query()
+```
+
+Set the managed pool limit before the first bridge call:
+
+```bash
+export SQLSPEC_ASYNC_THREAD_LIMIT=8
+```
+
+Programmatic controls:
+
+- `enable_default_async_thread_pool(max_workers=8)`
+- `set_default_async_executor(executor)`
+- `get_default_async_executor()`
+- `shutdown_default_async_executor(wait=False)`
+
+Precedence is explicit: `async_(fn, executor=...)` wins over `set_default_async_executor()`, which wins over SQLSpec's managed pool. Only `ThreadPoolExecutor` instances are accepted because SQLSpec preserves `contextvars` through bridge calls.
+
+---
+
+## Statement Cache And Fetch Tuning
+
+| Adapter | Knob | Use when | Avoid when |
+| --- | --- | --- | --- |
+| All drivers | `driver_features={"sqlspec_statement_cache_size": N}` | Same raw SQL text runs repeatedly with simple parameters | SQL text is high-cardinality or DDL changes affect result shapes |
+| `asyncpg` | `connection_config={"statement_cache_size": N}` | Long-lived PostgreSQL sessions repeat parameterized statements | PgBouncer transaction/statement pooling or frequent schema churn |
+| `psycopg` | `connection_config={"prepare_threshold": N}` | Repeated queries amortize server-side planning | Rarely repeated queries or connection middleware changes sessions |
+| `oracledb` | `connection_config={"stmtcachesize": N}` | Same Oracle statement text repeats frequently | Statement text has high cardinality or memory pressure dominates |
+| `oracledb` | `driver_features={"arraysize": N, "prefetchrows": N}` | Large result sets spend time on network round trips | Single-row lookups or very wide rows dominate |
+| `oracledb` | `driver_features={"fetch_lobs": False, "fetch_decimals": True}` | You need native LOB or NUMBER fetch representation | Application expects SQLSpec defaults |
+| `bigquery` | `driver_features={"query_page_size": N, "query_max_results": N}` | Bound page size or total rows for SELECT result fetching | DML and scripts; these controls apply to result fetching |
+| `arrow_odbc` | `driver_features={"chunk_size": N, "max_bytes_per_batch": N}` | Tune Arrow batch memory and round trips | Downstream requires a fixed batch shape |
+| `arrow_odbc` | `driver_features={"max_text_size": N, "max_binary_size": N, "fetch_concurrently": bool}` | Bound text/binary columns or improve high-latency fetches | Truncation is unacceptable or the ODBC source is unstable under concurrent fetch |
+
+Measure before changing defaults. Cache knobs help repeated statement text on stable sessions; fetch knobs tune network and memory after the query plan is already correct.
+
+---
+
+## BigQuery Job Controls
+
+Configure BigQuery job behavior through `BigQueryConfig.driver_features`.
+
+| Feature | Effect |
+| --- | --- |
+| `job_retry_deadline` | Total seconds for retry construction; `<= 0` disables the BigQuery job retry wrapper |
+| `job_result_timeout` | Bounds waits on `QueryJob.result()` and load-job completion |
+| `request_timeout` | Bounds the initial BigQuery API request; defaults from `job_result_timeout` when numeric |
+| `use_query_and_wait` | Uses `Client.query_and_wait()` for simple query execution |
+| `query_page_size` | Passed to `QueryJob.result()` for SELECT result fetching |
+| `query_max_results` | Total row cap passed to `QueryJob.result()` for SELECT result fetching |
+| `enable_storage_write_api` | Uses Storage Write API for `load_from_arrow(..., overwrite=False)` appends when available |
+
+Use the normal SQLSpec calls: `execute()`, `select()`, `select_to_arrow()`, `select_to_storage()`, `load_from_arrow()`, and `load_from_storage()`. SQLSpec does not expose `execute_with_job()` or `export_table_to_storage()`.
+
+Use `job_retry_deadline=0` for emulators or endpoints where retrying unsupported jobs extends failure time.
+
+---
+
+## Spanner Request And Session Controls
+
+Configure defaults through `SpannerSyncConfig.driver_features`:
+
+- `request_options` -- forwarded to `execute_sql()`, `execute_update()`, and `batch_update()`.
+- `directed_read_options` -- forwarded only to read calls using `execute_sql()`.
+- `retry` and `timeout` -- forwarded to statement execution calls.
+- `enable_batch_write_api` -- routes `load_from_arrow()` through Spanner Batch Write API for high-throughput mutation groups when `overwrite=False`.
+
+Per-call overrides use the existing driver methods:
+
+```python
+result = driver.execute(
+    "SELECT id FROM users WHERE id = @id",
+    {"id": "u-1"},
+    request_options={"request_tag": "users.lookup"},
+    directed_read_options=directed_read_options,
+    timeout=10.0,
+)
+```
+
+Session-scoped controls belong on `provide_session()`:
+
+```python
+with config.provide_session(
+    request_options={"transaction_tag": "orders.write"},
+    retry=retry,
+    timeout=20.0,
+) as driver:
+    driver.execute("UPDATE orders SET status = @status WHERE id = @id", params)
+```
+
+Use `provide_read_session()` for single-use snapshot reads. Use `provide_session()` or `provide_write_session()` for DDL, DML, and write-capable transactions.
+
+SQLSpec does not expose public `execute_with_options()`, `execute_partitioned_dml()`, `apply_mutations()`, or `provide_batch_snapshot()` methods.

--- a/skills/sqlspec/references/query_builder.md
+++ b/skills/sqlspec/references/query_builder.md
@@ -57,7 +57,7 @@ filters = [
 ]
 
 # The driver applies filters to the AST before execution
-rows = await db_session.select_many(base, *filters, schema_type=User)
+rows = await db_session.select(base, *filters, schema_type=User)
 
 # Or with pagination (returns items + total count)
 rows, total = await db_session.select_with_total(base, *filters, schema_type=User)
@@ -97,7 +97,7 @@ query = (
 | `.join(table, on=)` | INNER JOIN | `.join("orders", on="users.id = orders.user_id")` |
 | `.left_join(table, on=)` | LEFT JOIN | `.left_join("profiles", on="users.id = profiles.user_id")` |
 | `.where(expr)` | WHERE clause (AND-combined) | `.where("active = true")` |
-| `.where_eq(**kw)` | WHERE col = value (parameterized) | `.where_eq(status="active")` |
+| `.where_eq(column, value)` | WHERE col = value (parameterized) | `.where_eq("status", "active")` |
 | `.group_by(*cols)` | GROUP BY | `.group_by("department")` |
 | `.having(expr)` | HAVING clause | `.having("COUNT(*) > 5")` |
 | `.order_by(*exprs)` | ORDER BY | `.order_by("created_at DESC")` |
@@ -193,7 +193,7 @@ query = (
 query = (
     sql.update("users")
     .set(name="Bob", updated_at="now()")
-    .where_eq(id=1)
+    .where_eq("id", 1)
     .returning("id", "name")
 )
 
@@ -215,7 +215,7 @@ query = (
 query = (
     sql.delete()
     .from_("users")
-    .where_eq(id=1)
+    .where_eq("id", 1)
     .returning("id")
 )
 ```
@@ -248,7 +248,7 @@ query = sql.select("*").from_("users").where_eq("active", True)
 stmt = query.to_statement()
 
 # Execute via driver
-rows = await db_session.select_many(stmt, schema_type=User)
+rows = await db_session.select(stmt, schema_type=User)
 ```
 
 ### .compile(dialect=)

--- a/skills/sqlspec/references/service-patterns.md
+++ b/skills/sqlspec/references/service-patterns.md
@@ -92,7 +92,7 @@ Decision table:
 | A count or single cell | `select_value` |
 | One mapped object, must exist | `select_one` / `get_one` |
 | One mapped object, may be absent | `select_one_or_none` |
-| List of rows | `select_many` (via driver) or `paginate` (via service) |
+| List of rows | `select()` (via driver) or `paginate` (via service) |
 | INSERT/UPDATE/DELETE (no return) | `execute` |
 
 Example method combining `get_one` with a named template:

--- a/skills/sqlspec/references/starlette-integration.md
+++ b/skills/sqlspec/references/starlette-integration.md
@@ -289,7 +289,7 @@ async def list_orders(request: Request) -> JSONResponse:
     db: AsyncpgDriver = db_plugin.get_session(request)
     rows = await db.select(
         "SELECT id, status, amount FROM orders WHERE status = $1 ORDER BY id",
-        ["pending"],
+        "pending",
     )
     return JSONResponse({"orders": rows})
 
@@ -299,7 +299,9 @@ async def create_order(request: Request) -> JSONResponse:
     db: AsyncpgDriver = db_plugin.get_session(request)
     result = await db.execute(
         "INSERT INTO orders (customer_id, status, amount) VALUES ($1, $2, $3) RETURNING id",
-        [payload["customer_id"], "pending", payload["amount"]],
+        payload["customer_id"],
+        "pending",
+        payload["amount"],
     )
     return JSONResponse({"id": result.one()["id"]}, status_code=201)
 

--- a/skills/sqlspec/references/storage.md
+++ b/skills/sqlspec/references/storage.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-SQLSpec provides adapter-specific storage implementations for three integration points: ADK stores, event channel backends, and Litestar session stores. All are configured through the `extension_config` dict on adapter configs.
+SQLSpec provides adapter-specific storage implementations for Litestar session stores, event channel backends, and ADK session/event plus memory stores. Artifact service contracts are available under ADK, but adapter-specific concrete artifact metadata stores are deployment-provided. All integrations are configured through the `extension_config` dict on adapter configs.
 
 ---
 
@@ -18,9 +18,9 @@ config = AsyncpgConfig(
     connection_config={"dsn": "postgresql://localhost/app"},
     extension_config={
         "adk": {
-            "session_table": "adk_sessions",
-            "events_table": "adk_events",
-            "memory_table": "adk_memory_entries",
+            "session_table": "adk_session",
+            "events_table": "adk_event",
+            "memory_table": "adk_memory",
             "memory_use_fts": True,
         }
     },
@@ -34,11 +34,13 @@ await memory_store.ensure_tables()
 
 ### Available ADK Stores
 
-Every ADK-supported adapter provides its own store implementation. The stores handle:
+ADK-supported adapters are `asyncpg`, `psycopg`, `psqlpy`, `cockroach_asyncpg`, `cockroach_psycopg`, `aiomysql`, `asyncmy`, `mysqlconnector`, `pymysql`, `aiosqlite`, `sqlite`, `oracledb`, `duckdb`, `adbc`, and `spanner`. These stores handle:
 
 - Session rows and event history for `SQLSpecSessionService`
 - Memory rows for `SQLSpecMemoryService` / `SQLSpecSyncMemoryService`
 - Adapter-specific JSON, FTS, and transaction optimizations
+
+BigQuery is not an ADK backend. Use Spanner or an OLTP adapter for Google ADK session/event storage.
 
 ---
 
@@ -131,9 +133,9 @@ config = AsyncpgConfig(
         },
         # ADK session/event and memory stores
         "adk": {
-            "session_table": "adk_sessions",
-            "events_table": "adk_events",
-            "memory_table": "adk_memory_entries",
+            "session_table": "adk_session",
+            "events_table": "adk_event",
+            "memory_table": "adk_memory",
             "memory_use_fts": True,
         },
     },

--- a/skills/sqlspec/references/vector-search.md
+++ b/skills/sqlspec/references/vector-search.md
@@ -237,6 +237,6 @@ The `<=>` operator returns cosine distance (0 = identical, 2 = opposite); `1 - (
 
 ## Shared Styleguide Baseline
 
-- [`../litestar-styleguide/references/general.md`](../litestar-styleguide/references/general.md) — Cross-language baseline
-- [`../litestar-styleguide/references/python.md`](../litestar-styleguide/references/python.md) — Python conventions
-- [`../litestar-styleguide/references/litestar.md`](../litestar-styleguide/references/litestar.md) — Litestar-specific baseline
+- [`../../litestar-styleguide/references/general.md`](../../litestar-styleguide/references/general.md) — Cross-language baseline
+- [`../../litestar-styleguide/references/python.md`](../../litestar-styleguide/references/python.md) — Python conventions
+- [`../../litestar-styleguide/references/litestar.md`](../../litestar-styleguide/references/litestar.md) — Litestar-specific baseline

--- a/tests/hooks/test_detect_env.py
+++ b/tests/hooks/test_detect_env.py
@@ -214,6 +214,26 @@ def test_htmx_signal_triggers_htmx_skill(htmx_project: Path) -> None:
     assert "litestar:litestar-htmx" in str(out["context"])
 
 
+def test_litestar_queues_dependency_triggers_queues_skill(tmp_path: Path) -> None:
+    """litestar-queues dependencies should trigger the focused queues skill."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "worker"\ndependencies = ["litestar", "litestar-queues"]\n'
+    )
+    out = _run(tmp_path)
+    assert "litestar-queues" in out["detected_skills"]
+    assert "litestar:litestar-queues" in str(out["context"])
+
+
+def test_litestar_queues_import_triggers_queues_skill(tmp_path: Path) -> None:
+    """litestar_queues imports should trigger the focused queues skill."""
+    src = tmp_path / "src" / "myapp"
+    src.mkdir(parents=True)
+    (src / "tasks.py").write_text("from litestar_queues import Queue\n")
+    out = _run(tmp_path)
+    assert "litestar-queues" in out["detected_skills"]
+    assert "litestar:litestar-queues" in str(out["context"])
+
+
 def test_disable_env_var_short_circuits(litestar_project: Path) -> None:
     """LITESTAR_SKILLS_HOOK_DISABLE=1 should yield empty JSON object."""
     out = _run(litestar_project, env_overrides={"LITESTAR_SKILLS_HOOK_DISABLE": "1"})

--- a/tools/check-upstream-imports.py
+++ b/tools/check-upstream-imports.py
@@ -57,6 +57,7 @@ TARGET_ROOTS: frozenset[str] = frozenset(
         "litestar",
         "litestar_granian",
         "litestar_mcp",
+        "litestar_queues",
         "litestar_saq",
         "msgspec",
         "sqlalchemy",

--- a/tools/install.ps1
+++ b/tools/install.ps1
@@ -68,7 +68,7 @@ Set-StrictMode -Version Latest
 # =============================================================================
 # Constants
 # =============================================================================
-$script:Version = '0.4.0'
+$script:Version = '0.5.0'
 $script:RepoUrl = 'https://github.com/litestar-org/litestar-skills'
 $script:RepoSlug = 'litestar-org/litestar-skills'
 $script:MarketplaceName = 'litestar'

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -8,7 +8,7 @@
 #
 # Usage:
 #   tools/install.sh [--dry-run] [--force] [--only <host>] [--skip <host>]
-#   curl -fsSL https://raw.githubusercontent.com/litestar-org/litestar-skills/v0.4.0/tools/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/litestar-org/litestar-skills/v0.5.0/tools/install.sh | bash
 #
 # Hosts:
 #   claude     Claude Code        (prints instructions + optional settings edit)
@@ -20,7 +20,7 @@
 
 set -euo pipefail
 
-VERSION="0.4.0"
+VERSION="0.5.0"
 REPO_URL="https://github.com/litestar-org/litestar-skills"
 REPO_SLUG="litestar-org/litestar-skills"
 MARKETPLACE_NAME="litestar"

--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-VERSION="0.4.0"
+VERSION="0.5.0"
 PLUGIN_NAME="litestar"
 REPO_SLUG="litestar-org/litestar-skills"
 

--- a/uv.lock
+++ b/uv.lock
@@ -44,7 +44,7 @@ wheels = [
 
 [[package]]
 name = "alembic"
-version = "1.18.4"
+version = "1.18.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mako" },
@@ -52,9 +52,9 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/cc/ac0bed8e562e7407fe55c3ba85a4dce86e6dbd8730887bd1e406a6c5c18a/alembic-1.18.5.tar.gz", hash = "sha256:1554982221dd17e9a749b53902407578eb305e453f71999e8c7f0a48389fff8e", size = 2060480, upload-time = "2026-06-25T15:20:54.888Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+    { url = "https://files.pythonhosted.org/packages/96/78/5fe6dc3a3a5b2f5a2a4faef8bfe336d5fa049a38884ab3172e0098160c01/alembic-1.18.5-py3-none-any.whl", hash = "sha256:06d8ba9d04558022f5395e9317de03d270f3dced49cee01f89fe7a13c26f14bc", size = 264664, upload-time = "2026-06-25T15:20:56.673Z" },
 ]
 
 [[package]]
@@ -77,16 +77,16 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.14.0"
+version = "4.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/b5/001890774a9552aff22502b8da382593109ce0c95314abaebbb116567545/anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89", size = 253586, upload-time = "2026-06-15T22:00:49.021Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e", size = 254831, upload-time = "2026-06-24T20:56:06.017Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/16/9826f089383c593cdfc4a6e5aca94d9e91ae1692c57af82c3b2aa5e810f7/anyio-4.14.0-py3-none-any.whl", hash = "sha256:dd9b7a2a9799ed6552fde617b2c5df02b7fdd7d88392fc48101e51bae46164d9", size = 123506, upload-time = "2026-06-15T22:00:47.595Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72", size = 124875, upload-time = "2026-06-24T20:56:04.413Z" },
 ]
 
 [[package]]
@@ -278,11 +278,11 @@ wheels = [
 
 [[package]]
 name = "bracex"
-version = "2.6"
+version = "3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/f5/4473ad9b48cd0420a2d762a3750fa0e078e23e060b1af72662e5987e5530/bracex-3.0.tar.gz", hash = "sha256:b73f718d6bd98d8419e45df02426c86e9967c179949f779340d6c3a8c83b9111", size = 43162, upload-time = "2026-06-30T00:43:35.279Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2e/68781b78e764e5ccc4af1e3d27e060069c73af90234853fa80000e7ee79d/bracex-3.0-py3-none-any.whl", hash = "sha256:3833e61c2f092d5aa0468fa2e6c6e990a306185abf763b6d122f0158e59c58a5", size = 11738, upload-time = "2026-06-30T00:43:34.196Z" },
 ]
 
 [[package]]
@@ -503,14 +503,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.4.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -755,7 +755,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.138.0"
+version = "0.138.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -764,9 +764,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/58/ff455d9fe47c60abadb34b9e05a304b1f05f5ab8000ac01565156b6f5e43/fastapi-0.138.0.tar.gz", hash = "sha256:d445a4877636ad191e7053e08c9bf98cb921a6756776848400bb773d1740c061", size = 419240, upload-time = "2026-06-20T01:18:05.259Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/a9/9f8f7e00195c29836e9bf58bbbaf579e29878b8a67851efff93d9b6d4eb7/fastapi-0.138.2.tar.gz", hash = "sha256:6432359d067a432134620e7c5e4c6e5063e7f37815bbbbf20acef14b0d2e3fc8", size = 420423, upload-time = "2026-06-29T12:44:12.556Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/ff/8496d9847a5fedae775eb49460722d3efaa80487854273e9647ae876218c/fastapi-0.138.0-py3-none-any.whl", hash = "sha256:b6f54fd1bd72c80b0f899f172c61a600f6f7af9b43d4d772a018f35624048cb0", size = 126779, upload-time = "2026-06-20T01:18:03.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b3/38be2c074bdd0c986340db1d72d7b2321b805b1c5a68069aa00b5d31fd02/fastapi-0.138.2-py3-none-any.whl", hash = "sha256:db90c1ffb5517fba5d4a9f80e866daa008747e646310c9ce155c8c535f9d1615", size = 129271, upload-time = "2026-06-29T12:44:13.905Z" },
 ]
 
 [[package]]
@@ -832,15 +832,15 @@ wheels = [
 
 [[package]]
 name = "google-auth"
-version = "2.55.0"
+version = "2.55.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/1c/70b23fc52b2bb3c70b379f3bd05c4a60ab3a873e30c6bd21c57e0154848a/google_auth-2.55.0.tar.gz", hash = "sha256:fcd3a130f575fa36403d38774af1c64a4fbfbca09215f0589d2372b5119697cb", size = 349379, upload-time = "2026-06-15T22:33:16.466Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/6f/f3f4ac177c67bbee8fe8e88f2ab4f36af88c44a096e165c5217accf6e5d3/google_auth-2.55.1.tar.gz", hash = "sha256:fb2d9b730f2c9b8d326ec8d7222f21aef2ead15bf0513793d6442485d87af0a1", size = 349527, upload-time = "2026-06-25T23:39:27.182Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/71/c0321dc6d63d99946da45f7c06299b934e4f7f7da5c4f14d101bcb39adf1/google_auth-2.55.0-py3-none-any.whl", hash = "sha256:a17cef9dedf98c4ebae2fb0c48c8f75952c877cbc2efe09f329ef16c2783d88a", size = 252400, upload-time = "2026-06-15T22:33:14.992Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/1d/f6d3ca1ad0725f2e08a1c6915640748a52de2e66596160a4d53b010cccf0/google_auth-2.55.1-py3-none-any.whl", hash = "sha256:eada68dfd52b3b81191827601e2a0c3fa12540c818534b630ddc5355769c3995", size = 252349, upload-time = "2026-06-25T23:38:52.946Z" },
 ]
 
 [package.optional-dependencies]
@@ -853,7 +853,7 @@ requests = [
 
 [[package]]
 name = "google-genai"
-version = "2.9.0"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -867,9 +867,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/75/81c01294db3a3005dc8a807ed889a10ecd66ef89462c118adcffa5f7981c/google_genai-2.9.0.tar.gz", hash = "sha256:a8a10e9113f460cc668c1d9deeb62ba393ad1ba704bf3166d5a0f32a434f9415", size = 595700, upload-time = "2026-06-19T08:23:42.718Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/fe/b796087493c3c55371aa58b9f264841ace5bfdf8c668cafa7afa33c44bec/google_genai-2.10.0.tar.gz", hash = "sha256:77912cd558cd7dfd5b75c25fd1c609e78d7954dde583331104022a46ea90f9ee", size = 600039, upload-time = "2026-06-24T01:33:18.157Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/17/bb2cdd0a6c6fec32f14e85735917d1052f82430b1de58c2b606740740419/google_genai-2.9.0-py3-none-any.whl", hash = "sha256:2a79e2b08e8439f5f25c2b42f98e3f3e8ea4be9c9265f5d7321580dbaf2764f4", size = 950790, upload-time = "2026-06-19T08:23:40.995Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/39/00bcfd94de255d24249401efff4f48d77bf6066b46447e519fa193c0c299/google_genai-2.10.0-py3-none-any.whl", hash = "sha256:d5350311567ae660c24cbc1752aee4b3d660f89c0106d2dcd2a69978c35afe1e", size = 957974, upload-time = "2026-06-24T01:33:16.296Z" },
 ]
 
 [[package]]
@@ -980,88 +980,88 @@ wheels = [
 
 [[package]]
 name = "greenlet"
-version = "3.5.2"
+version = "3.5.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dd/8b/befc3cb36965f397d87e86fb3b00e3ec0dc67c1ecb0986d7f54ee528f018/greenlet-3.5.2.tar.gz", hash = "sha256:c1b906220d83c140361cdd12eef970fb5881a168b98ee58a43786426173da14c", size = 199243, upload-time = "2026-06-17T20:19:01.317Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/f1/fbbfef6af0bad0548f09bc28948ea3c275b4edb19e17fc5ca9900a6a634d/greenlet-3.5.3.tar.gz", hash = "sha256:a61efc018fd3eb317eeca31aba90ee9e7f26f22884a79b6c6ec715bf71bb62f1", size = 200270, upload-time = "2026-06-26T19:28:24.832Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/3a/cd99db55dc908568f6b91845747b98b3b17a06052fa1803d091dc91da27d/greenlet-3.5.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:9df9daae96848508450011d0d86ed7c95f8829a354ce438284a77b24896fd1f8", size = 285626, upload-time = "2026-06-17T17:33:33.231Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/09/fd997a19cbb97641233c7d5f8fc89314c132be2c8867c4f14beff979996f/greenlet-3.5.2-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01e32e9d2b1714a2b06184cb3071ff2a2fd9bc7d065e39198ab21f7253dad421", size = 601821, upload-time = "2026-06-17T18:07:16.756Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/b0/62abd204addd913ad9856e091f5d8baaedc7c85df151f22f093b8a207c20/greenlet-3.5.2-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0488ca77c94da5e09d1d9958f98b58cebba1b8fd9664c24898499133de927574", size = 615044, upload-time = "2026-06-17T18:29:39.344Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/5f/0f1db88a69c427e57091079b1478ae8e704de289b4f564ec573b3cdac38a/greenlet-3.5.2-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bc18b8d33e6976804b9b792fe11cb3b1fee8b646e8a9e20bf521a429ddf73520", size = 621981, upload-time = "2026-06-17T18:39:23.961Z" },
-    { url = "https://files.pythonhosted.org/packages/34/67/ceaab731b51611a8238b0af2d4abb4fd727ec09b16cd499fca5295603f46/greenlet-3.5.2-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6d9e19257794e28821c9ebd5e23f86d7c267cd9d390089374f068d2049f949e3", size = 615176, upload-time = "2026-06-17T17:39:25.134Z" },
-    { url = "https://files.pythonhosted.org/packages/47/bc/8c0c0768765eb57851bf65202e675e5ce6615fc4ce11d0e10be903cdc919/greenlet-3.5.2-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:2c6d6bfa4fdd7c39a0dbf112cdf28edbd19c517c810eefb6e4e71b0d55933a4c", size = 417918, upload-time = "2026-06-17T18:41:16.46Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/40/51a0ee73b72a7e4a65b54433316bbd7b3b7902a585310cd4e3051d411ee3/greenlet-3.5.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:bf493b3c1c0a2324c49b0472e2280ba4665f3510d8115f6f807759a6163b15f7", size = 1574580, upload-time = "2026-06-17T18:22:09.082Z" },
-    { url = "https://files.pythonhosted.org/packages/41/d3/a3a2163b1fe73042d3e72cfcb9920f2481d5188a1df2645587a9b83a903f/greenlet-3.5.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:561dd919c02236a613fbf226791cbd77ee5002cbd5cb7e838869aa3ac7a71e16", size = 1641192, upload-time = "2026-06-17T17:40:04.234Z" },
-    { url = "https://files.pythonhosted.org/packages/95/a3/b4d83fb451e2f7266cb45ccef23857f8a800e0a5d9a73263fafdf7ba7904/greenlet-3.5.2-cp310-cp310-win_amd64.whl", hash = "sha256:049827baab63dda8ab8ec5a6d07fc6eb0f418319cfc757fc8737a605e99ca1ad", size = 238247, upload-time = "2026-06-17T17:34:54.794Z" },
-    { url = "https://files.pythonhosted.org/packages/21/68/371ee6dad168be3386c46030bedaa8e3e7e3cf3d203621d4529e78ff36ef/greenlet-3.5.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:d7792398872f89466c6671d5d193537eff163ecf7fac78d82e6ddc25017fb4f5", size = 286925, upload-time = "2026-06-17T17:33:17.928Z" },
-    { url = "https://files.pythonhosted.org/packages/26/16/ed5706c26b4d26f3fabceb79abca992654eac8b0fa435def2ac6dbd92122/greenlet-3.5.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:711028c953cd6ce5dc01bbb5a1747e3ad6bd8b2f7ded73778bb936e8dab9e3b6", size = 606036, upload-time = "2026-06-17T18:07:18.538Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/32/f9c77093af9f5f96615922b7e3fe3690a9faff02adb89f1d74e21578b147/greenlet-3.5.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5eba55076d79e8a5176e6925295cfb901ebc95dae493342ede22230f75d8bee2", size = 617821, upload-time = "2026-06-17T18:29:41.317Z" },
-    { url = "https://files.pythonhosted.org/packages/27/f5/a963a939039aa5acafc2f9535f6cc8958ad30afe1478e2e37ab5098af74d/greenlet-3.5.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1724499fc08388208408681c53c5062e9803c334e5a0bdaeb616228ba882aac8", size = 625675, upload-time = "2026-06-17T18:39:25.767Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/d4/642833e778c17d32b5cabb793e14ce7364c55952462fc506fecdee55d485/greenlet-3.5.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1c1e5ad80f1f38ea479b83b39dccb20874cfe9ad5e52f87225fa294ba4d39a1", size = 616877, upload-time = "2026-06-17T17:39:26.564Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/c8/995a898ebbf44e3da0b7ea6fbc1631518c185fb83467a5d6cf408d6d3ced/greenlet-3.5.2-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:e976f9f6941f57d87a194c91868622c8b22a142a741d2fde31655c319133ade6", size = 420572, upload-time = "2026-06-17T18:41:18.035Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/cc/7120f83e78b8be3cf7acbe2306b3b7bd2cbf99f5ad12e85e2f05d7b31961/greenlet-3.5.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9e194b996aa1b89d933cfe136e5eb39b22a8b72ba59d376ef39a55bca4dbf47f", size = 1577274, upload-time = "2026-06-17T18:22:10.692Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/d8/05a0074ee485dd51c320fd706fd7ed48006b9cad3443092d7df1a655f0d2/greenlet-3.5.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4e554809538bd4867f24421b43abde170f9c9b8192149b30df5e164bcac6124f", size = 1643566, upload-time = "2026-06-17T17:40:05.452Z" },
-    { url = "https://files.pythonhosted.org/packages/35/fe/9fe2060bdeece682e38d381184ae66045b48ed183c107ab3f88b9886a630/greenlet-3.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:e063263ce9047878480d7e536012fc8b7c8e1922989eb5f03b9ab998a2ee7b7e", size = 238643, upload-time = "2026-06-17T17:37:03.039Z" },
-    { url = "https://files.pythonhosted.org/packages/41/13/a9db72f5b6b700977ebd371d6a1f2984a08838357de924fcd5571607b1bf/greenlet-3.5.2-cp311-cp311-win_arm64.whl", hash = "sha256:a3f76a94e2d6e1fee8f302265679d8cc47d71a203936dd03c6e2ace0f9cfd46d", size = 237135, upload-time = "2026-06-17T17:34:34.14Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/7a/6bc2a7835731387ed303b9390ce68a116ab053df05450a59181239200454/greenlet-3.5.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:76dae33e97b52743a19210931ee3e78a88fe1438bc2fc4ee5e7512d289bfad4f", size = 288351, upload-time = "2026-06-17T17:36:17.019Z" },
-    { url = "https://files.pythonhosted.org/packages/57/1b/bd98062fcef6d0e9d0873ab6f2d029772e6ea342972ae43275bd6177900f/greenlet-3.5.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30252d191d6959df1d040b559a38fc017139606c5ecc2ad00416557c0355d742", size = 604273, upload-time = "2026-06-17T18:07:20.296Z" },
-    { url = "https://files.pythonhosted.org/packages/25/e6/fe392c522bf45d976abe7db2793f6ef4e87b053ebb869deeaae46aeb54da/greenlet-3.5.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1adc23c50f22b0f5979521909a8360ab4a3d3bef8b641ce633a04cf1b1c967ea", size = 616536, upload-time = "2026-06-17T18:29:43.205Z" },
-    { url = "https://files.pythonhosted.org/packages/42/df/cdb1f75f07214f13110e7e3879531f11c26083bd480a56a9474c430ec44c/greenlet-3.5.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:87359c23eb4e8f1b16da68faad29bf5aeb80e3628d7d8e4aa2e41c36879ddedd", size = 621843, upload-time = "2026-06-17T18:39:27.507Z" },
-    { url = "https://files.pythonhosted.org/packages/68/4a/399ff81fa93a19d6a9df394cef0355f082dbc19ad41aba9593cd0ad444e2/greenlet-3.5.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f052fff492c52fdfa99bd3b3c1389a53de37dae76a0562741417f0d018f02b3", size = 613749, upload-time = "2026-06-17T17:39:28.148Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/25/36a3628a7edcfeefddd3101dc88039c79721c5f8d688db7ebed1cbaaa789/greenlet-3.5.2-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:f4d67c1684db3f9782c37ee4bade3f86f5a23a8fcf3f8359224106018ca40728", size = 424889, upload-time = "2026-06-17T18:41:19.469Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/75/f519593f12ad43d08e28c03a95cfe2eeae011707dbc9dab0c4a263ce90f9/greenlet-3.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:120b77c2a18ebf629c3a7886f68c6d01e065654844ad468f15bb93ace66f2094", size = 1573725, upload-time = "2026-06-17T18:22:12.023Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/bc/bc1ea4b0754c6c51bbf9d94677b0b1f7fbda8cbb404e44a896854fc0a940/greenlet-3.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a850f6224088ef7dcc70f1a545cb6b3d119c35d6dca63b925b9f35da0635cdad", size = 1638132, upload-time = "2026-06-17T17:40:06.971Z" },
-    { url = "https://files.pythonhosted.org/packages/36/c0/f0f5a34247df60de285f75f22e57f14027f4b3c43820981854b5b643ca6d/greenlet-3.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:89da99ee8345b458ea2f16831dad31c88ddcdec454b48704d569a0b8fb28f146", size = 239393, upload-time = "2026-06-17T17:33:47.09Z" },
-    { url = "https://files.pythonhosted.org/packages/09/17/a8544e165445f30aea67a8d9cf2786d2bb0eb1b0e0d224b4d9bd80e2d587/greenlet-3.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:ca92411942154023c65851e6077d8ca0d00f19de5fa80bb2c6f196ff6c920ba9", size = 237723, upload-time = "2026-06-17T17:36:47.776Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/3c/bb37b9d40d65b0741a8b040ca5c307034d0a9822994dff5f825c88dd7a6b/greenlet-3.5.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:0629377725977252159de1ebd3c6e49c170a63856e585446797bb3d66d4d9c34", size = 287178, upload-time = "2026-06-17T17:35:25.132Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/a6/0c5902393f492f8ceb19d0b5cf139284e3a11b333a049739643b1036b6f8/greenlet-3.5.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2ddf9eddc617681108dd071b3feabf3f4a4cd64846254aec4d4ceda098b639a", size = 606900, upload-time = "2026-06-17T18:07:21.692Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/7c/42899c31d4b87148ae4e3f87f63e13398824be6241f4dde42ded95768a34/greenlet-3.5.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f41feb9f2b59e2e61ac9bea4e344ddd9396bf3cacb2583f73a3595ed7df6f8e7", size = 619265, upload-time = "2026-06-17T18:29:44.837Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/7e/28f991affb413b232b1e7d768db24c37b3f4d5daecc3f19b455d40bd2dea/greenlet-3.5.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9dc23f0e5ad76415457212a4b947d22ebe4dc80baf02adf7dd5647a90f38bb4e", size = 625044, upload-time = "2026-06-17T18:39:29.046Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/52/4ff8c98d3cfe62b4515f8584ae14510a58f35c549cc5292b78d9b7a40b70/greenlet-3.5.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:09201fa698768db245920b00fdc86ee3e73540f01ca6db162be9632642e1a473", size = 616187, upload-time = "2026-06-17T17:39:29.473Z" },
-    { url = "https://files.pythonhosted.org/packages/29/05/0cc9ec660e7acff85f93b0a048b6654371c822c884add44c02a465cf70e0/greenlet-3.5.2-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:423167363c510a75b649f5cd58d873c29498ea03598b9e4b1c3b73e0f899f3d5", size = 427322, upload-time = "2026-06-17T18:41:20.892Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/a6/269c8bf9aefc13361ce1088f0e392b154cb21005de7862e42b5d782b81fd/greenlet-3.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a1759fa4f14c398508cf20dc8037de55cc23ae8bd14c185c2718257837195ca5", size = 1573778, upload-time = "2026-06-17T18:22:13.497Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/9b/391d015cbc6323e81b14c02cf825fdca7e0049c9bb489bf4ac72883118ba/greenlet-3.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b9318cdeb9abdbfdd8bc8464ee4a06dffde2c7846e1def138365a6240ab2c9a5", size = 1638092, upload-time = "2026-06-17T17:40:08.163Z" },
-    { url = "https://files.pythonhosted.org/packages/49/53/5b4df711f4356c62e85d9f819d87966d526d1cfb32bae49a8f7d6fc36ea4/greenlet-3.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:2c3b3311af72b3d3b03cc0f1ffd11f072e834be5d0444105cf715fc44434e39c", size = 239352, upload-time = "2026-06-17T17:38:51.593Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/b6/18efc3a329ec035c3f344b8f2b60356451950ddf9b7b64ff00023778a1dd/greenlet-3.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:f9bbd6216c45a563c2a61e478e038b439d9f248bde44f775ea37d339da643af4", size = 237635, upload-time = "2026-06-17T17:35:36.632Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/89/aaafc8e14de4ac882e02ccb963225329b0e8578aba4365e71eb678e45722/greenlet-3.5.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:1c31219badba285858ba8ed117f403dea7fafee6bade9a1991875aae530c3ceb", size = 287676, upload-time = "2026-06-17T17:33:31.514Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/fc/2308249206c12ac70de7b9a00970f84f07d10b3cd60e05d2fbcaa84124e8/greenlet-3.5.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6f96ed6f4adc1066954ae95f45717657cb67468ef3b89e9a3632e14a625a8f39", size = 653552, upload-time = "2026-06-17T18:07:23.493Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/24/47730d1f8f1336b9b089237521ed7a26eee997065dcb4cab81cdca333abc/greenlet-3.5.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5795e883e915333c0d5648faaa691857fbc7180136883edc377f50f0d509c2a8", size = 665756, upload-time = "2026-06-17T18:29:46.616Z" },
-    { url = "https://files.pythonhosted.org/packages/23/5c/2664d290cbd1fef9eb3f69b5d3bc5aa91b6fa907519298ca6af93a90c6cb/greenlet-3.5.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6e9e49d732ee92a189bb7035e293029244aeba648297a9b856dc733d17ca7f0d", size = 669989, upload-time = "2026-06-17T18:39:30.79Z" },
-    { url = "https://files.pythonhosted.org/packages/99/69/d6c99db15dc0b5e892ac3cc7b942c8b21f4a9cc3bd9ea0bc3b0f339ffbd4/greenlet-3.5.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:26aed8d9503ca78889141a9739d71b383efea5f472a7c522b5410f7eb2a1b163", size = 663228, upload-time = "2026-06-17T17:39:31.073Z" },
-    { url = "https://files.pythonhosted.org/packages/42/d4/fcb53fa9847d7fbd4723fbed9469c3869b9e3544c4e001d9d5aa2f66162d/greenlet-3.5.2-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:537c5c4f30395020bb9f48f53146070e3b997c3c75da14011ab732aaa19ce3ef", size = 472888, upload-time = "2026-06-17T18:41:22.511Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/88/9e603f448e2bc107c883e95817b980fb9b45ba6aea0299b2e9978124bea2/greenlet-3.5.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:dbebc038fcdda8f8f21cce985fd04e34e0f42007e7fc7ab7ad285caf77974b95", size = 1620723, upload-time = "2026-06-17T18:22:14.817Z" },
-    { url = "https://files.pythonhosted.org/packages/11/91/26da17e3777858c16fdb8d020a4c68f3a03cb92f238de8f5351d5d5186e9/greenlet-3.5.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a207023f1cf8695fd82580b8099c09c5809be18bc2282362cdfb965dd884a317", size = 1684227, upload-time = "2026-06-17T17:40:09.536Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/44/b3a11f7aa34cb38f1b7f3df8bcd9fcd09bac9d342c2a2c9b8686c804bcd2/greenlet-3.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:c674a1dd4fe41f6a93febe7ab366ceabf15080ea31a9307811c56dac5f435f73", size = 240257, upload-time = "2026-06-17T17:35:23.359Z" },
-    { url = "https://files.pythonhosted.org/packages/de/e3/3b62145fe917311732041a258adb218248add00542e3131c48bd047fbed5/greenlet-3.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:3c417cd6c593bbbef6f7aa31a79f37d3db7d18832fc56b694a2150130bde784e", size = 239038, upload-time = "2026-06-17T17:37:56.792Z" },
-    { url = "https://files.pythonhosted.org/packages/47/ac/d3bad483e9f6cd1848604fdffa32cac25846dd6dfcec0e6f81c790185518/greenlet-3.5.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a96457a30384de52d9c5d2fd33abf6c1daae3db392cd556738f408b1a79a1cf0", size = 295668, upload-time = "2026-06-17T17:36:02.293Z" },
-    { url = "https://files.pythonhosted.org/packages/00/e9/3a7e557b895fd0469b00cd0b2bd498ba950e8bfdf6d7adeecf2c5e4130a6/greenlet-3.5.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e4af5d4961818ab651d09c1448a03b1ba2a1726a076266ebb62330bab9f3238c", size = 652820, upload-time = "2026-06-17T18:07:24.95Z" },
-    { url = "https://files.pythonhosted.org/packages/78/67/6225d5c5e4afc04be0fd161eec82e4b72017e8a100d222f25d7b42b0140d/greenlet-3.5.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a1789a6244ea1ba61fd4386c9a6a31873e9b0234762103364be98ef87dcb19f3", size = 658697, upload-time = "2026-06-17T18:29:48.365Z" },
-    { url = "https://files.pythonhosted.org/packages/35/ad/9b3058f999b81750a9c6d9ec424f509462d232b58002086fe2ba63b66407/greenlet-3.5.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2ee6288f1933d698b4f098127ed17bda2910a75d2807915bd16294a972055d6c", size = 658945, upload-time = "2026-06-17T18:39:32.509Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/99/6324b8ef916dcaddccb340b304c992ca3f947614ce0f2685d438187300b8/greenlet-3.5.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3be00501fb4a8c37f6b4b3c4773808ceb26ea65c7ea64fd5735d0f330b3786de", size = 656436, upload-time = "2026-06-17T17:39:32.509Z" },
-    { url = "https://files.pythonhosted.org/packages/92/75/1b6ecd8c027b69ab1b6798a84094df79aab5e69ac7e249c78b9d361dd1fa/greenlet-3.5.2-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:b4cad42662c796334c2d24607c411e3ed82481c1fb4e1e8ec3a5a8416060092e", size = 490529, upload-time = "2026-06-17T18:41:23.954Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/ee/f5bf9daac27c5e1b011965f64b5630a32b415daf7381b312943629e12c2a/greenlet-3.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1d554cd96841a68d464d75a3736f8e87408a7b02b1930a75fa32feb408ad62f8", size = 1617193, upload-time = "2026-06-17T18:22:16.252Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/21/b05d5b12715bda92ce27c118d64971d21e9b8f3563ed959a7d271e2d4223/greenlet-3.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3dff6cd3aac35f6cd3fc23460105acf576f5faf6c378de0bc088bf37c913864a", size = 1677512, upload-time = "2026-06-17T17:40:10.771Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/97/1b8f1314b868041b327dc1051603e8142b826480cb0ecb8a7b7632aee9c4/greenlet-3.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:36cfea2aa075d544617176b2e84450480f0797070ad8799a8c41ada2fe449d32", size = 243145, upload-time = "2026-06-17T17:34:37.502Z" },
-    { url = "https://files.pythonhosted.org/packages/36/07/1b5311775e04c718a118c504d7a3a312430e2a1bd1347226aff4774e4549/greenlet-3.5.2-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:a0314aa832c94633355dc6f3ee54f195159533355a323f26926fc63b98b2ccbb", size = 288315, upload-time = "2026-06-17T17:34:34.04Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/cc/6abcd2a486b58b9f77b7a93b690d59cb2c11a5906ed2ad4c63c7b9c1113d/greenlet-3.5.2-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24c59cb7db9d5c694cb8fd0c76eef8e456b2123afdfa7e4b8f2a67a0860d7682", size = 659130, upload-time = "2026-06-17T18:07:26.354Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/12/f4aaad6d3d383233f700ab322568a4f29f2c701a4861d85f4811d99689b2/greenlet-3.5.2-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7bb811753703739ad318112f16eccfaabdac050037b6d092debaa8b23566b4ce", size = 669724, upload-time = "2026-06-17T18:29:50.13Z" },
-    { url = "https://files.pythonhosted.org/packages/53/e0/4ce3a046b51e53934eae93d7f9c13975a97285741e9e1fcadf8751314c37/greenlet-3.5.2-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2debcd0ef9455b7d4879589903efc8e497d4b8fb8c0ae772309e44d1ca5e957f", size = 673494, upload-time = "2026-06-17T18:39:34.196Z" },
-    { url = "https://files.pythonhosted.org/packages/91/2a/a089811fc31c6bf8742f40a4e73470d6d401cef18e4314eb20dc399b377c/greenlet-3.5.2-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6d78b5c1c178dad90447f1b8452262709d3eef4c98f825569e74c9d0b2260ac9", size = 668089, upload-time = "2026-06-17T17:39:33.808Z" },
-    { url = "https://files.pythonhosted.org/packages/52/e0/9c18721e63445dce02ee67e4c81c0f281626604ff55ae6f7b7f4354d7129/greenlet-3.5.2-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:9558cae989faeab6fbb425cd98a0cfa4190a47fba6443973fbee0a1eb0b0b6c3", size = 479721, upload-time = "2026-06-17T18:41:25.726Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/1c/2f47c7d5fcfa98a62b705bf9a0505d86f4563c0d81cab1f7159ff1e743b7/greenlet-3.5.2-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:0977af2df83136f81c1f76e76d4e2fe7d0dc56ea9c101a86af26a95190b9ca32", size = 1625684, upload-time = "2026-06-17T18:22:17.664Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/bf/661dd24624f70b7b32972d7693d0344ecde10278f647d7b828baf739899c/greenlet-3.5.2-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:f9ed777c6891d8253e54468576f55e27f8fc1a662a664f946a191003574c0a74", size = 1688043, upload-time = "2026-06-17T17:40:12.403Z" },
-    { url = "https://files.pythonhosted.org/packages/60/49/d9bde1d15a21296b3b521fe083eb8aabd54ac05d15de9832918f3d639543/greenlet-3.5.2-cp315-cp315-win_amd64.whl", hash = "sha256:c0ea4eb3de23f0bac1d75205e10ccfa9b418b17b01a2d7bf19e3b69dda08900a", size = 240531, upload-time = "2026-06-17T17:35:47.448Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/4d/86d7768bd53e9907de0333df215c2018cd01a593b3715cbd79aa82dd94b7/greenlet-3.5.2-cp315-cp315-win_arm64.whl", hash = "sha256:7a7bfc200be40d04961d7e80e8337d726c0c1a50777e588123c3ed8ba731dcb9", size = 239579, upload-time = "2026-06-17T17:39:39.954Z" },
-    { url = "https://files.pythonhosted.org/packages/92/15/907be5e8900901039bae752fa9a31c03a3c1e064833f35a4e49449184581/greenlet-3.5.2-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:98a52d6a50d4deaba304331d83ee3e10ebbdc1517fcca40b2715d1de4534065c", size = 296697, upload-time = "2026-06-17T17:37:15.887Z" },
-    { url = "https://files.pythonhosted.org/packages/95/5c/08c57be575c3d6a3c023bbf22144a1c7dc6ed4d134527bb36ded4dbf04a8/greenlet-3.5.2-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1587ff8b58fdf806993ed1490a06ac19c22d47b219c68b30954380029045d8d4", size = 656710, upload-time = "2026-06-17T18:07:28.046Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/d0/749f917bdc9fc90fceea4aa65fbf6556e617a50714d1496bdc8ad190bb36/greenlet-3.5.2-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:feb721811d2754bfd16b48de151dd6b1f222c048e625151f2ca44cfdfd69f59c", size = 662629, upload-time = "2026-06-17T18:29:51.728Z" },
-    { url = "https://files.pythonhosted.org/packages/55/87/10776cd88df54d0f563e9e21e98363f2d6af94bedc553b1da0972fa87f80/greenlet-3.5.2-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a9476cbead736dc48ce89e3cd97acff95ecc48cbf21273603a438f9870c4a014", size = 663191, upload-time = "2026-06-17T18:39:35.639Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/a5/68cefae3a07f6d0093a490cf28ab604f14578f3e60205a2a2b2d5cd70af2/greenlet-3.5.2-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7fe6062b1f35534e1e8fb28dfed406cf4eeff3e0bca3a0d9f8ff69f20a4abb00", size = 660147, upload-time = "2026-06-17T17:39:35.068Z" },
-    { url = "https://files.pythonhosted.org/packages/02/aa/26ddf92826a99d87bfb8fdb8f3a262a6f16495a5d8e579737baa92fb4543/greenlet-3.5.2-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:5930d3946ecae99fa7fc0e3f3ae515426ad85058ebd9bfc6c00cca8016e6206b", size = 498199, upload-time = "2026-06-17T18:41:27.464Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/6b/b9156d8397e4750220f54c7c5c34650f1e740a8d2f66eab9cfd1b7b53b69/greenlet-3.5.2-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:b4ac902af825cbac8e9b2fccab8122236fd2ba6c8b71a080116d2c2ec72671b1", size = 1621675, upload-time = "2026-06-17T18:22:18.873Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/e3/d3250f4fa01c211a93d04e34fded63187e648dbec17b9b1a14d388040593/greenlet-3.5.2-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:6f1e473c06ae8be00c9034c2bb10fa277b08a93287e3111c395b839f01d27e1f", size = 1680577, upload-time = "2026-06-17T17:40:14.055Z" },
-    { url = "https://files.pythonhosted.org/packages/55/ba/eaee8bda4419770d7096b5a009ebff0ab20a2a28cdd83c4b591bfdf36fa9/greenlet-3.5.2-cp315-cp315t-win_amd64.whl", hash = "sha256:3c2315045f9983e2e50d7e89d95405c21bddb8745f2da4487bc080ab3525f904", size = 243482, upload-time = "2026-06-17T17:37:34.741Z" },
-    { url = "https://files.pythonhosted.org/packages/37/45/f794a81c91e9942c61f9110bd1f9a38a0ea565eab57f8b08cd53d3131e48/greenlet-3.5.2-cp315-cp315t-win_arm64.whl", hash = "sha256:db548d5ab6c2a8ead82c013f875090d79b5d7d2b67fc513934ce6cf66492ad7f", size = 242062, upload-time = "2026-06-17T17:35:39.814Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/a1/1f7f0c555f5858fd2906fe9f7b0a3554fddb85cb70df7a6aaec41dc292c2/greenlet-3.5.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:c180d22d325fb613956b443c3c6f4406eb70e6defc70d3974da2a7b59e06f48c", size = 285838, upload-time = "2026-06-26T18:21:05.167Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/29/be9f43ed61677a5759b38c8a9389248133c8c731bbfc0574ecdff66c99fc/greenlet-3.5.3-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:483d08c11181c83a6ce1a7a61df0f624a208ec40817a3bb2302714592eee4f04", size = 602342, upload-time = "2026-06-26T19:07:06.908Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/42/ba41c97ec36aa4b3ec25e5aa691d79561254805fad7f2f826dd6770587e2/greenlet-3.5.3-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1dae6e0091eae084317e411f047f0b7cb241c6db570f7c45fd6b900a274914ce", size = 615541, upload-time = "2026-06-26T19:10:04.909Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/8c/231ca675b0df779816950ca66b40b1fa14dbff4a0ed9814a9a29ec399140/greenlet-3.5.3-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0f6ff50ff8dbd51fae9b37f4101648b04ea0df19b3f50ab2beb5061e7716a5c8", size = 622473, upload-time = "2026-06-26T19:24:12.786Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/c7/28747042e1df8a9cd120a1ebe15529fc4be3b486e13e8d551ff307a82412/greenlet-3.5.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9bcd2d72ccd70a1ec68ba6ef93e7fbb4420ef9997dabc7010d893bd4015e0bec", size = 615675, upload-time = "2026-06-26T18:32:14.444Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fe/dd97c483a3ff82849196ccd07851600edd3ac9de74669ca8a6022ada9ea1/greenlet-3.5.3-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:37bf9c538f5ae6e63d643f88dec37c0c83bdf0e2ebc62961dedcf458822f7b71", size = 418421, upload-time = "2026-06-26T19:25:34.503Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a8/b85525a6c8fba9f009a5f7c8df1545de8fb0f0bf3e0179194ef4e500317f/greenlet-3.5.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:73f152c895e09907e0dbe24f6c2db37beb085cd63db91c3825a0fcd0064124a8", size = 1575057, upload-time = "2026-06-26T19:09:00.264Z" },
+    { url = "https://files.pythonhosted.org/packages/03/79/fb76edb218fe6735ab0edeba176c7ab80df9618f7c02ce4208979f3ae7db/greenlet-3.5.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8bdb43e1a1d1873721acab2be99c5befd4d2044ddfd52e4d610801019880a702", size = 1641692, upload-time = "2026-06-26T18:31:41.454Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/79/86fe3ee50ed55d9b3907eecd3208b5c3fe8a79515519aae98b4753c3fa1d/greenlet-3.5.3-cp310-cp310-win_amd64.whl", hash = "sha256:0909f9355a9f24845d3299f3112e266a06afb68302041989fd26bd68894933db", size = 238742, upload-time = "2026-06-26T18:20:40.758Z" },
+    { url = "https://files.pythonhosted.org/packages/51/58/5404031044f55afad7aad1aff8be3f22b1bed03e237cfeabbc7e5c8cfde0/greenlet-3.5.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:aca9b4ce85b152b5524ef7d88170efdff80dc0032aa8b75f9aaf7f3479ea95b4", size = 287424, upload-time = "2026-06-26T18:20:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/bf/1c65e9b94a54d547068fa5b5a8a06f221f3316b48908e08668d29c77cb50/greenlet-3.5.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f71be4920368fe1fabeeaa53d1e3548337e2b223d9565f8ad5e392a75ba23fc", size = 606523, upload-time = "2026-06-26T19:07:08.859Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/b66baacc95775ad511287acb0137b95574a9ce5491902372b7564799d790/greenlet-3.5.3-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4d77e67f65f98449e3fb83f795b5d0a8437aead2f874ca89c96576caf4be3af6", size = 618315, upload-time = "2026-06-26T19:10:06.055Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/a0/68afd1ebad40db87dac0a28ffa120726b98bf9c7c40c481b0f63c105d298/greenlet-3.5.3-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e18619ba655ac05d78d80fc83cac4ba892bd6927b99e3b8237aee861aaacc8bb", size = 626155, upload-time = "2026-06-26T19:24:14.44Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2b/28ed29463522fdbe4c15b1f63922041626a7478316b34ab4adda3f0a4aba/greenlet-3.5.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8540f1e6205bd13ca0ce685581037219ca54a1b41a0a15d228c6c9b8ad5903d7", size = 617381, upload-time = "2026-06-26T18:32:16.077Z" },
+    { url = "https://files.pythonhosted.org/packages/07/7f/e327d912239ec4b3b49999e3967389bcf1ee8722b9ee9194d2752ecd558a/greenlet-3.5.3-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:d27c0c653a60d9535f690226474a5cc1036a8b0d7b57504d1c4f89c44a07a80c", size = 421083, upload-time = "2026-06-26T19:25:35.804Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7b/ad04e9d1337fc04965dc9fc616b6a72cb65a24b800a014c011ec812f5489/greenlet-3.5.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7ef56fe650f50575bf843acde967b9c567687f3c22340941a899b7bc56e956a8", size = 1577771, upload-time = "2026-06-26T19:09:01.537Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/33/6c87ab7ba663f70ca21f3022aad1ffe56d3f3e0521e836c2415e13abcc3c/greenlet-3.5.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5121af01cf911e70056c00d4b46d5e9b5d1415550038573d744138bacb59e6b8", size = 1644048, upload-time = "2026-06-26T18:31:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/35/f0d8ee998b422cf8693b270f098e55d8d4ec8006b061b333f54f177d28d9/greenlet-3.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:0f41e4a05a3c0cb31b17023eff28dd111e1d16bf7d7d00406cd7df23f31398a7", size = 239137, upload-time = "2026-06-26T18:23:21.664Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/96/b9820295576ef18c9edc404f10e260ae7215ceaf3781a54b720ed2627862/greenlet-3.5.3-cp311-cp311-win_arm64.whl", hash = "sha256:ec6f1af59f6b5f3fc9678e2ea062d8377d22ac644f7844cb7a292910cf12ff44", size = 237630, upload-time = "2026-06-26T18:24:00.281Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/6e/4c37d51a2b7f82d2ff11bb6b5f7d766d9a011726624af255e843727627a3/greenlet-3.5.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:719757059f5a53fd0dde23f78cffeafcdd97b21c850ddb7ca684a3c1a1f122e2", size = 288685, upload-time = "2026-06-26T18:22:08.977Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/73/815dd90131c1b71ebdf53dbc7c276cafec2a1173b97559f97aba72724a87/greenlet-3.5.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa9f765dd09f9d0cdac651ffdf631ee59ec5dc6ee7a73e0c012ba9c52fbdf5b", size = 604761, upload-time = "2026-06-26T19:07:10.114Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/57/079cfe76bcef36b153b25607ee91c6fcb58f17f8b23c86bbbeabe0c88d72/greenlet-3.5.3-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7faba15ac005376e02a0384504e0243be3370ce010296a44a820feb342b505ab", size = 617044, upload-time = "2026-06-26T19:10:07.25Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/fb/d97dc261209c80744b7c8132693a30d70ec6e7315e632cb0a10b3fec94dd/greenlet-3.5.3-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5795cd1101371140551c645f2d408b8d3c01a5a29cf8a9bce6e759c983682d23", size = 622351, upload-time = "2026-06-26T19:24:16.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/87/b4d095775a3fb1bcafbb483fc206b27ebb785724c83051447737085dc54e/greenlet-3.5.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87142215824be6ac05e2e8e2786eec307ccbc27c36723c3881959df654af6861", size = 614244, upload-time = "2026-06-26T18:32:17.594Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/e5fee13cbbd0e8de312d9a146584b8a51891c68847330ef9dc8b5109d23f/greenlet-3.5.3-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:af4923b3096e26a36d7e9cf24ab88083a20f97d191e3b97f253731ce9b41b28c", size = 425395, upload-time = "2026-06-26T19:25:37.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/70/7559b609683650fa2b95b8ab84b4ab0b26556a635d19675e12aa832d826d/greenlet-3.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:215275b1b49320987352e6c1b054acca0064f965a2c66992bed9a6f7d913f149", size = 1574210, upload-time = "2026-06-26T19:09:03.077Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/73/be55392074c60fc37655ca40fa6022457bfbf6718e9e342a7b0b41f96dd2/greenlet-3.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6b1b0eed82364b0e32c4ea0f221452d33e6bb17ae094d9f72aed9851812747ea", size = 1638627, upload-time = "2026-06-26T18:31:44.748Z" },
+    { url = "https://files.pythonhosted.org/packages/14/40/c57489acf8e37d74e2913d4eff63aa0dba17acccc4bdeef874dde2dbbec9/greenlet-3.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:cde8adafa2365676f74a979744629589999093bc86e2484214f58e61df08902c", size = 239882, upload-time = "2026-06-26T18:23:27.518Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/6fea0e3d6600f785069481ee637e09378dd4118acdfd38ad88ae2db31c98/greenlet-3.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:c4e7b79d83805475f0102008843f6eb45fd3bb0b2e88c774adab5fbaab27117d", size = 238211, upload-time = "2026-06-26T18:22:37.671Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ff/a620267401db30a50cc8450ee90730e2d4a85658c055c0e760d4ed47fb13/greenlet-3.5.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:c8d87c2134d871df96ecdea9cec7cbaab286dadab0f56476e57aaf9e8ac11550", size = 287609, upload-time = "2026-06-26T18:21:14.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fa/5401ac78021c826a25b6dde0c705e0a8f29b617509f9185a31dac15fbe1b/greenlet-3.5.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2d185dd1621757e70c3861cceffd5317ab4e7ed7eb09c82994828468527ade5", size = 607435, upload-time = "2026-06-26T19:07:11.412Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/76/1dc144a2e56e65d36405078ed774224375ea520a1870a6e46e08bb4ac7bf/greenlet-3.5.3-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1c514a468149bf8fbbab874188a3535cd8a48a3e353eb53a3d424296f8dbacd3", size = 619787, upload-time = "2026-06-26T19:10:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/57/61/2f5b1adf256d039f5dab8005de8d3d7ad2b0070a3219c0e036b3fbfeb440/greenlet-3.5.3-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9ad04dd75458c6300b047c61b8639092433d205a25a14e310d6582a480efcca1", size = 625580, upload-time = "2026-06-26T19:24:18.344Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/87/c298cee62df1de4ad7fec32abda73526cff347fd143a6ed4ac369246668a/greenlet-3.5.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:915f887cf2682b66419b879423a2e072634aa7b7dce6f3ada4957cfced3f1e9a", size = 616786, upload-time = "2026-06-26T18:32:19.128Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d9/ab7fc9e543e44d6879b0a6ef9a4b2188940fd180cc65d6f646883ddf7201/greenlet-3.5.3-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:afaabdd554cd7ae9bbb3ca070b0d7fdfd207dbf1d16865f7233837709d354bda", size = 427933, upload-time = "2026-06-26T19:25:38.219Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2e/e6f009885ed0705ccf33fe0583c117cfd03cde77e31a596dd5785a30762b/greenlet-3.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:766cfd421c13e450feb340cd472a3ed9957d438727b7b4593ad7c76c5d2b0deb", size = 1574316, upload-time = "2026-06-26T19:09:04.273Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fe/43fd110b01e40da0adb7c90ac7ea744bef2d43dca00de5095fd2351c2a68/greenlet-3.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2ecda9ec22edf38fa389369eaed8c3d37c05f3c54e69f69438dbb2cc1de1458b", size = 1638614, upload-time = "2026-06-26T18:31:46.297Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/7c/062447147a61f8b4337b156fe70d32a165fcf2f89d7ca6255e572806705c/greenlet-3.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:c82304750f057167ff60d188df1d0cc1764ce9567eadf03e6a7443bcedd0b30b", size = 239850, upload-time = "2026-06-26T18:21:54.613Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7e/220a7f5824a64a60443fc03b39dfac4ea63a7fb6d481efa27eafa928e7f4/greenlet-3.5.3-cp313-cp313-win_arm64.whl", hash = "sha256:dc133a1569ee667b2a6ef56ce551084aeefd87a5acbc4736d336d1e2edc6cfc4", size = 238141, upload-time = "2026-06-26T18:22:48.507Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/93/43e116ee114b28737ba7e12952a0d4e2f55944d0f84e42bc91ba7192a3c9/greenlet-3.5.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:fd2e02fa07485778536a036222d616ab957b1d533f36b3ed98ce725d9c9d3117", size = 288202, upload-time = "2026-06-26T18:23:49.604Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2f/146d218299046a43d1f029fd544b3d110d0f175a09c715c7e8da4a4a345d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df0a0628d1597eb0897b62f55d1343f772405fd25f3b2a796c76874b0c2e22e8", size = 654096, upload-time = "2026-06-26T19:07:12.71Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cc/04738cafb3f45fa991ea44f9de94c47dcec964f5a972300988a6751f49d9/greenlet-3.5.3-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ebd933a6adabc298bab47731a130fe6bfb888bd934eee37810f151159544540d", size = 666304, upload-time = "2026-06-26T19:10:09.503Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a9/73fa62893d5b84b4205544e6b673c654cc43aa5b9899bac00f04d64af73d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8d19fe6c39ebff9259f07bcc685d3290f8fa4ea2278e51dd0008e4d6b0f2d814", size = 670657, upload-time = "2026-06-26T19:24:19.967Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/aa/4e0dad5e605c270c784ab911c43da6adb136ccd4d81180f763ca429a723d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b9d501b40e80b70e32323c799dd9b420a5577a9601469d362ae1ffb690f3a7c", size = 663635, upload-time = "2026-06-26T18:32:20.802Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7e/2ffce64929fb3cab7b65d5a0b20aaf9764e227681d731b041077fc9a525a/greenlet-3.5.3-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:962c5df2db8cb446da51edf1ca5296c389d93b99c9d8aa2ee4c7d0d8f1218260", size = 473497, upload-time = "2026-06-26T19:25:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/50/13efdbea246fe3d3b735e191fec08fb50809f53cd2383ebe123d0809e44b/greenlet-3.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a1fad1d11e7d6aab184107baa8e4ece11ccba3ec9599cd7efa5ff4d70d43256a", size = 1621252, upload-time = "2026-06-26T19:09:05.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/22/c0a336ae4a1410fd5f5121098e5bfbf1865f64c5ef80b4b5412886c4a332/greenlet-3.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fad5aec764399f1b5cc347ad250a59660f20c8f8888ea6bae1f93b769cce1154", size = 1684824, upload-time = "2026-06-26T18:31:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/94/91aec0030bea75c4b3244251d0de60a1f3432d1ecb53ab6c437fb5c3ba61/greenlet-3.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:7669aa24cf2a1041d6f7899575b494a3ab4cf68bfcc8609b1dc0be7272db835e", size = 240754, upload-time = "2026-06-26T18:22:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/06/68d0983e79e02138f64b4d303c500c27ddb48e5e77f3debb80888a921eae/greenlet-3.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:5b4807c4082c9d1b6d9eed56fcd041863e37f2228106eef24c30ca096e238605", size = 239549, upload-time = "2026-06-26T18:22:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/91/95/3e161213d7f1d378d15aa9e792093e9bfe01844680d04b7fd6e0107c9098/greenlet-3.5.3-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:271a8ea7c1024e8a0d7dd2be66dd66dda8a07193f41a17b9e924f7600f5b62be", size = 296389, upload-time = "2026-06-26T18:22:20.657Z" },
+    { url = "https://files.pythonhosted.org/packages/00/92/715c44721abe2b4d1ae9abde4179411868a5bff312479f54e105d372f131/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19131729ae0ddc3c2e1ef85e650169b5e37ee32e400f215f78b94d7b0d567310", size = 653382, upload-time = "2026-06-26T19:07:14.209Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/83/37a10372a1090a6624cca8e74c12df1a36c2dc36429ed0255b7fb1aeee23/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1540dd8e5fc2a5aec40fbb98ef8e149fa47c89a4b4a1cf2575a14d3d1869d7a8", size = 659401, upload-time = "2026-06-26T19:10:10.876Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/73/8faec206b851c22b1733545fda900829a1f3f5b1c78ae7e0fb3dba57d9f4/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b897d97759425953f69a9c0fac67f8fe333ec0ce7377ef186fb2b0c3ad5e354d", size = 659582, upload-time = "2026-06-26T19:24:21.357Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e2/d1509cad4207da559cc42986ecdd8fc67ad0d1bba2bf03023c467fd5e0f3/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e81fa194a1d20967877bdf9c7794db2bc99063e5be36aee710c08f04c5bb087f", size = 656969, upload-time = "2026-06-26T18:32:22.272Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/55/50c19e49f8045834ada71ef12f8ad048eba8517c6aa41161bed676328fae/greenlet-3.5.3-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:3236754d423955ea08e9bb5f6c04a7895f9e22c290b66aa7653fcb922d839eb0", size = 491037, upload-time = "2026-06-26T19:25:40.672Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7d/eaf70de20aadca3a5884aec58362861c64ce45e7b277f47ed026926a3b89/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55cf4d777485d43110e47133cbba6d74a8885a87ec1227ef0267f9ee80c5aa21", size = 1617822, upload-time = "2026-06-26T19:09:06.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f9/414d38fc400ae4350d4185eaad1827676f7cf5287b9136e0ed1cbbe20a7f/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:12a248ba75f6a9a236375f52296c498c89ff1d8badf32deb9eca7abd5853f7da", size = 1677983, upload-time = "2026-06-26T18:31:49.396Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/15/7edb977e08f9bff702fe42d6c902702786ff6b9694058b4e6a2a6ac90e57/greenlet-3.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:efc6bd60ea02e085862c74a3ef64b147ffc6f1a5ea7d9f26e7a939943f68c1e3", size = 243626, upload-time = "2026-06-26T18:24:41.485Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8a/93928dce91e6b3598b5e779e8d1fd6576a504640c58e78627077f6a7a91a/greenlet-3.5.3-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:ea03f2f04367845d6b58eeed276e1e56e51f0b97d8ad5a88a7d20a91dc9056cc", size = 288860, upload-time = "2026-06-26T18:22:48.07Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ca/69db42d447a1378043e2c8f19c09cbbd1263371505053c496b49066d3d16/greenlet-3.5.3-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78dbef602fda6d97d957eb7937f70c9ce9e9527330347f8f6b6f9e554a9e7a47", size = 659747, upload-time = "2026-06-26T19:07:15.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0b/af7ac2ef8dd41e3da1a40dda6305c23b9a03e13ba975ec916357b50f8575/greenlet-3.5.3-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f73857adb8fee13fa56c172bd11262f888c0c648f9fea113e777bb2c7904a81", size = 670419, upload-time = "2026-06-26T19:10:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/25/aa/952cf28c2ff949a8c971134fb43854dd7eaa737218723aaef758f8c9aead/greenlet-3.5.3-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cefa9cef4b371f9844c6053db71f1138bc6807bab1578b0dae5149c1f1141357", size = 674261, upload-time = "2026-06-26T19:24:22.79Z" },
+    { url = "https://files.pythonhosted.org/packages/51/1e/1d51640cacbfc455dbe9f9a9f594c49e4e244f63b9971a2f4764e46cc53d/greenlet-3.5.3-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:232fec92e823addaf02d9472cf7381e24a1d046a6ced1103c5caa4c21b9dfc1d", size = 668787, upload-time = "2026-06-26T18:32:24.298Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f2/b00d6f5e63e531a93562b2ec1a4c320fbee91f580fc42e6417af69d706e5/greenlet-3.5.3-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:6219b6d04dbf6ba6084d77dc609e8473060dc55f759cbf626d512122781fa128", size = 480322, upload-time = "2026-06-26T19:25:41.852Z" },
+    { url = "https://files.pythonhosted.org/packages/21/66/4030d5b0b5894500023f003bb054d9bb354dfbd1e186c3a296759172f5f5/greenlet-3.5.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:2421c3564da9429d5586d46ca31ebb26516b5498a802cf65c041a8e8a8980d34", size = 1626305, upload-time = "2026-06-26T19:09:08.281Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/50/5221371c7550108dfa3c378debc41d032aa9c78e89abb01d8011cfc93289/greenlet-3.5.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e0f0d160f0b2e558e6c75f7930967183255dc9735e5f5b8cae58ee09c9576d8b", size = 1688631, upload-time = "2026-06-26T18:31:51.278Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5d/00d469daae3c65d2bf620b10eee82eb022127d483c6bc8c69fae6f3fbf17/greenlet-3.5.3-cp315-cp315-win_amd64.whl", hash = "sha256:dd99329bbc15ca78dcc583dba05d0b1b0bae01ab6c2174989f5aaee3e41ac930", size = 241027, upload-time = "2026-06-26T18:22:38.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/883785b44c5780ed71e83d3e4437e710470be17a2e181e8b601e2da0dc4a/greenlet-3.5.3-cp315-cp315-win_arm64.whl", hash = "sha256:499fef2acede88c1864a57bb586b4bf533c81e1b82df7ab93451cdb47dfec227", size = 240085, upload-time = "2026-06-26T18:23:54.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/da/4f4a8450962fad137c1c8981a3f1b8919d06c829993d4d476f9c525d5173/greenlet-3.5.3-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:176bc16a721fa5fc294d70b87b4dfa5fbdd251b3da5d5372735ecef9bd7d6d0c", size = 297221, upload-time = "2026-06-26T18:23:27.176Z" },
+    { url = "https://files.pythonhosted.org/packages/57/66/b3bfae3e220a9b63ea539a0eea681800c69ab1aada757eae8789f183e7ce/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:629b614d2b786e89c50440e246f33eea78f58a962d0bdbbcc809e6d13605903f", size = 657221, upload-time = "2026-06-26T19:07:16.973Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/81/b6d4d73a709684fc77e7fa034d7c2fe82cffa9fc920fadcaa659c2626213/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b2e857ae16f5f72142edf75f9f176fe7526ba19a2841df1420516f83831c9f2", size = 663226, upload-time = "2026-06-26T19:10:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/39/0e0938a75115b939d42733a2a12e1d349653c9531fe6fe563e8a681f04e6/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16d192579ed281051396dddd7f7754dac6259e6b1fb26378c87b66622f8e3f91", size = 663706, upload-time = "2026-06-26T19:24:24.312Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/07/e210b02b589f16e74ff48b730690e4a34ffe984219fce4f3c1a0e7ec8545/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e515757e2e36bcbf1fad09a46e1557e8b1ae1797d4b44d09da7deed88ad28608", size = 660802, upload-time = "2026-06-26T18:32:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/41/35d1c678cdb3c3b9e6bee691728e563cfb294202b23c7a4c3c2ccc343589/greenlet-3.5.3-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:4399eb8d041f20b68d943918bc55502a93d6fdc0a37c14da7881c04139acee9d", size = 498803, upload-time = "2026-06-26T19:25:43.063Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/2e/5303eb3fa06bca089060f479707182a93e360683bc252acf846c3090d34e/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:b363d46ed1ea431825fdb01471bb024fc08399bad1572a616e853c7684415adb", size = 1622157, upload-time = "2026-06-26T19:09:09.527Z" },
+    { url = "https://files.pythonhosted.org/packages/54/70/50de47a488f14df260b50ae34fb5d56016e308b098eab02c878b5223c26a/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:e44da2f5bbdaabaf7d80b73dbb430c7035771e9f244e3c8b769715c9d8fa0a16", size = 1681159, upload-time = "2026-06-26T18:31:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/13/1055e1dda7882073eda533e2b96c62e55bbd2db7fda6d5ece992febc7071/greenlet-3.5.3-cp315-cp315t-win_amd64.whl", hash = "sha256:8ff8bed3e3baa20a3ea261ce00526f1898ad4801d4886fd2220580ee0ad8fadf", size = 244007, upload-time = "2026-06-26T18:22:04.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/ca7d15afbdc397e3401134c9e1800d51d12b829661786187a4ad08fe484f/greenlet-3.5.3-cp315-cp315t-win_arm64.whl", hash = "sha256:b7068bd09f761f3f5b4d214c2bed063186b2a86148c740b3873e3f56d79bac31", size = 242586, upload-time = "2026-06-26T18:23:37.93Z" },
 ]
 
 [[package]]
@@ -1097,15 +1097,15 @@ wheels = [
 
 [[package]]
 name = "httpcore2"
-version = "2.4.0"
+version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "h11" },
     { name = "truststore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/9b/2b1d1833a58236d1f6ee755e027a3917da0db59cc9708554cefc440ee8b6/httpcore2-2.4.0.tar.gz", hash = "sha256:3093a8ab8980d9f910b9cb4351df9186a0ad2350a6284a9107ac9a362a584422", size = 64618, upload-time = "2026-06-11T06:35:53.425Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/5c12df521b5322fb1114a83d46911b2fbcb8855ddb3a635f11c01a214af5/httpcore2-2.5.0.tar.gz", hash = "sha256:88aa170137c17328d5ac44234f9fd10706466d5fb347f3edac4d39b91137b09d", size = 64808, upload-time = "2026-06-25T14:16:56.472Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/72/4fdf2306143a92a471fad9f3655aa542d43aa9188a7c9534e82c9aecf837/httpcore2-2.4.0-py3-none-any.whl", hash = "sha256:5218779da5d6e3c2013ac706121abfb3815d450e0613495c0de50264dce58242", size = 80151, upload-time = "2026-06-11T06:35:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a1/7564199d1a8728fe737b0a72e5b3f8d92dfe085a74ddf7cdd83bce5f206d/httpcore2-2.5.0-py3-none-any.whl", hash = "sha256:5ce35188de461d31e8d000bfb8ef8bf22c6c16587a211e5571deaa5e9bdf842a", size = 80330, upload-time = "2026-06-25T14:16:53.634Z" },
 ]
 
 [[package]]
@@ -1175,7 +1175,7 @@ wheels = [
 
 [[package]]
 name = "httpx2"
-version = "2.4.0"
+version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1184,9 +1184,9 @@ dependencies = [
     { name = "truststore" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/60/b43ced4ccf26e95b396dbf67051d3e5042b645917d4da0469dd82a3bdd4f/httpx2-2.4.0.tar.gz", hash = "sha256:32e0734b61eb0824b3f56a9e98d6d92d381a3ef12c0045aa917ee63df6c411ef", size = 81691, upload-time = "2026-06-11T06:35:54.538Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/e2/b5dedc0cf35aa65de5f541ccd30d2bc1fd7f1d43c9ab09f8ed9a7342317b/httpx2-2.5.0.tar.gz", hash = "sha256:e2df9cb4611021527ff8a675b1c320b610a2ec397acc8d6fe6e91df2d9b33c29", size = 83121, upload-time = "2026-06-25T14:16:57.491Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/45/82bc57c3d9c3314f663b67cc057f1c017a6450685dde513f4f8db5cf431f/httpx2-2.4.0-py3-none-any.whl", hash = "sha256:425acd99297829599decf6701386dd84db3542597d36d3e2e4def930ecd57fd9", size = 74941, upload-time = "2026-06-11T06:35:52.235Z" },
+    { url = "https://files.pythonhosted.org/packages/31/22/859d8252dad9bc9adee34b52e62cde621ece07b042ccb2ab4da1be46695f/httpx2-2.5.0-py3-none-any.whl", hash = "sha256:3d2d4d9cf4b61f1a1f46a95947cfdb47e80cb56a2f91c6256ac8f58e4891df41", size = 76652, upload-time = "2026-06-25T14:16:55.23Z" },
 ]
 
 [[package]]
@@ -1230,14 +1230,14 @@ wheels = [
 
 [[package]]
 name = "joserfc"
-version = "1.7.1"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/90/25cb27518750218e4f850be63d8bbb2343efaad1c01c3571aaa4b3c33bd7/joserfc-1.7.1.tar.gz", hash = "sha256:77d0b76514879c68c6f433bc5b7357a4ab72008ff1e33d8379fd11d72bd8ca81", size = 233181, upload-time = "2026-06-08T07:21:33.412Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/26/abe1ad855eb334b5ebc9c6495d4798e12bee70e5e8e815d54570710b8312/joserfc-1.7.2.tar.gz", hash = "sha256:537ffb8888b2df039cb5b6d017d7cff6f09d521ce65d89cc9b8ab752b1cff947", size = 233183, upload-time = "2026-06-29T09:03:10.868Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/00/fa62404c3e347f946faa13aa21085205f9cc06ad17671e37f81a51662ae8/joserfc-1.7.1-py3-none-any.whl", hash = "sha256:b3e3d655612e2e1ef67b2600f2f420e12e537b020208fab1761fad647319c164", size = 70423, upload-time = "2026-06-08T07:21:32.001Z" },
+    { url = "https://files.pythonhosted.org/packages/13/80/d1b30336582cced4dce0dae776508a6011723e32f907bc7a702c0b25890a/joserfc-1.7.2-py3-none-any.whl", hash = "sha256:ddd818c0ca9b4f17bbc2d72cb3966e6ded7502be089316c62c3cc64ae86132b5", size = 70426, upload-time = "2026-06-29T09:03:09.393Z" },
 ]
 
 [[package]]
@@ -1413,16 +1413,29 @@ wheels = [
 
 [[package]]
 name = "litestar-mcp"
-version = "0.7.2"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "litestar", extra = ["jwt"] },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/b9/98cba8538155079d91daf0d1916c0a207bae857efb14c69faab5582ee800/litestar_mcp-0.7.2.tar.gz", hash = "sha256:3581a97575acf2dabc6fc71bbaae6fc44875b24422936e822cb50a2c20b275f9", size = 545981, upload-time = "2026-06-11T16:52:07.277Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/8c/129ac07d09f6cb8c2f076a4e2411e7c3f43a271b17a89a3d42f1f3daf28d/litestar_mcp-0.9.0.tar.gz", hash = "sha256:8a3afd47ca955cc90f81b9b8c12624174d50c2dbd24302738e764527d0888243", size = 561229, upload-time = "2026-06-29T00:53:31.793Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/ae/a5fb0c5dee725fe2f89bd5c952d1c1a0b5e735294390d221aa729715bade/litestar_mcp-0.7.2-py3-none-any.whl", hash = "sha256:f58157a752020b731bc8165106c4465bfb65308718795b14813855eea83c3f3d", size = 84440, upload-time = "2026-06-11T16:52:05.728Z" },
+    { url = "https://files.pythonhosted.org/packages/34/b2/6944ac862a1294c733c045f1eb2fe90606882dc12e5e120cbfb7d8cf4d57/litestar_mcp-0.9.0-py3-none-any.whl", hash = "sha256:22958d7e4af9ba7c9816693c49d1bc85e76c6d0275a36588459fe194c4500907", size = 91289, upload-time = "2026-06-29T00:53:30.27Z" },
+]
+
+[[package]]
+name = "litestar-queues"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "litestar" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/01/5903380376c0f63692220b942a3127ff2e71ea3cc0b4ef4b71f9645de57c/litestar_queues-0.1.0.tar.gz", hash = "sha256:8e1dc1ef303d374637195eb72a52eab581ecac23bab17e7b992f2119a3580afd", size = 373474, upload-time = "2026-06-29T20:51:12.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/aa/2454268a450b7f8494cbba2a8fe90fceeafef338b31df1302424b64c9eae/litestar_queues-0.1.0-py3-none-any.whl", hash = "sha256:4ee7bbe0543503724087170fdb864351377c60b1f6981ed6bab0bc0874c16afb", size = 117524, upload-time = "2026-06-29T20:51:10.756Z" },
 ]
 
 [[package]]
@@ -1440,7 +1453,7 @@ wheels = [
 
 [[package]]
 name = "litestar-skills"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -1463,6 +1476,7 @@ validation = [
     { name = "litestar", extra = ["jinja", "jwt"] },
     { name = "litestar-granian" },
     { name = "litestar-mcp" },
+    { name = "litestar-queues" },
     { name = "litestar-saq" },
     { name = "pytest-databases" },
     { name = "sanic", extra = ["ext"] },
@@ -1478,7 +1492,8 @@ requires-dist = [
     { name = "flask", marker = "extra == 'validation'", specifier = ">=3.0" },
     { name = "litestar", extras = ["jinja", "jwt"], marker = "extra == 'validation'", specifier = ">=2.23" },
     { name = "litestar-granian", marker = "extra == 'validation'", specifier = ">=0.10" },
-    { name = "litestar-mcp", marker = "extra == 'validation'", specifier = ">=0.7" },
+    { name = "litestar-mcp", marker = "extra == 'validation'", specifier = ">=0.9" },
+    { name = "litestar-queues", marker = "extra == 'validation'", specifier = ">=0.1" },
     { name = "litestar-saq", marker = "extra == 'validation'", specifier = ">=0.5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.380" },
@@ -2289,15 +2304,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.410"
+version = "1.1.411"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/53/e4d8ea1391bd4355231be6f91bf239479aa0014260ed3fb5526eeb12a1f2/pyright-1.1.410.tar.gz", hash = "sha256:07a073b8ba6749826773c1269773efa11b93440d9a6aa60419d9a3172d6dc488", size = 4062013, upload-time = "2026-06-01T17:35:48.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/33/288b5868fa00846dacf249633719d747893e54aebd196b9968ac1878a5d3/pyright-1.1.410-py3-none-any.whl", hash = "sha256:5e961bed37cacf96b3f7cd7b1da39b350a9239aa2e69138d0e88f728cfaf296c", size = 6082448, upload-time = "2026-06-01T17:35:46.387Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
 ]
 
 [[package]]
@@ -2804,27 +2819,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.18"
+version = "0.15.20"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/74/98/1295ad5a5aa9bc85bdcdfa5d82fe7b49c61af5657df4f227637ff9de0da6/ruff-0.15.18.tar.gz", hash = "sha256:2698a964c70e8bf402dcb99c8810472d270d141e7aa8c4e13599fd52033a2f33", size = 4761437, upload-time = "2026-06-18T18:25:39.224Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/d0/686e984941269621e2be72612d5c1e461f8f7b38415a2a7d7a81c8ae6715/ruff-0.15.18-py3-none-linux_armv6l.whl", hash = "sha256:8b6850172348c8381b8b3084c5915a4393c2373b9b54cd5b5e1ea15812bc10df", size = 10887308, upload-time = "2026-06-18T18:25:03.062Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/21/bc4123e3f5515ee99f8ce1eb93a14a0628fe4d1678663cd08f933ac16931/ruff-0.15.18-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3fccc153a85417dcd976883160cacce486997b0a0058dd18f54b8aaaac7d1ce2", size = 11281305, upload-time = "2026-06-18T18:25:30.026Z" },
-    { url = "https://files.pythonhosted.org/packages/51/93/4769464c25cf7ab2acb3c7dda9cad3d867eb41c59565b3e2a9d17249c90c/ruff-0.15.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:08d4c86a68f2c3ec2c9d56380a71fb4a4f65373055cbb8caabd645e9102f38d4", size = 10641215, upload-time = "2026-06-18T18:25:15.802Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/42/56926d17120db2c208d76bf60a1a019644dd9e91dc27f0f95c9caddb1366/ruff-0.15.18-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37e5108745c2c0705da916d7d4de533ddf547051ef45f62888c31bae73f66318", size = 10957224, upload-time = "2026-06-18T18:25:36.955Z" },
-    { url = "https://files.pythonhosted.org/packages/22/4f/d43fab8d8189afde803103022d000a8ef9f230616d436d52a8b2b8d63b50/ruff-0.15.18-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56949a6ce8b3abde54c0bcb22cebfe57e8771cadc84b407ae8b8eaf67ebdcd43", size = 10699024, upload-time = "2026-06-18T18:25:05.707Z" },
-    { url = "https://files.pythonhosted.org/packages/63/42/1e3e4c68bd408b9768cf3e439acbe2c78245225faef253f7028a0cdb63e0/ruff-0.15.18-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:01a754cd6a1b630d3f97e33eb452cf7a98040482318e870f8bc52a5a30e62657", size = 11491458, upload-time = "2026-06-18T18:25:20.275Z" },
-    { url = "https://files.pythonhosted.org/packages/20/77/47a3484bea8521e14a203d98c389c5c97846675e4f02734672da4a69b52a/ruff-0.15.18-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ba7a07e03a44dbf10bb086ee06705b173625014ec99f73a7e6836a5e5590a0c", size = 12383752, upload-time = "2026-06-18T18:25:22.535Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/ca/054159590787023d83b658a1a1819c4c8910114e7015069340b71c0961cb/ruff-0.15.18-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5a2c40a41a4cadbcf5897b548ab29dfe248b20c540961c0247d98a3973c70403", size = 11577923, upload-time = "2026-06-18T18:25:10.702Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/ff/d353d6b7bbd73cc0ec37f4463d7540e45e894338abdd9964eee0de332708/ruff-0.15.18-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f0480ce690cbb6c4db6e5d08f19fce98e10ba131a8b60c1bcdac42771e3ae2d", size = 11583925, upload-time = "2026-06-18T18:25:32.391Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/4a/891f89b9c296ed3e5f3ece1a5629badc989d9a8fdaa30431aaf4774bc1c2/ruff-0.15.18-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2330215f1f393fa8733f55edce04fcf94c36a2c460fcde31f78cc84e4951e9b1", size = 11582834, upload-time = "2026-06-18T18:25:27.309Z" },
-    { url = "https://files.pythonhosted.org/packages/32/a3/ed9e370154bf85de360b93c03026157f02d4943b2d01ff4945f4429f8e8a/ruff-0.15.18-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6aa6a3d979e48ae617578183674bf264fbe7d0114a796a26bd678d67963c7ff", size = 10927328, upload-time = "2026-06-18T18:25:34.676Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/d1/5cf5909329fedb5d39d555ee818ba5cf4638e1a301b89785d34f2905bfcb/ruff-0.15.18-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a81beadbbff2c9c245561ae3f77b16709d87f35eec650d0501679239d3449b22", size = 10693187, upload-time = "2026-06-18T18:25:08.245Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/44/ff6c635cf2c4f4e7b618b6640da057376baa36014695487d88aed4794268/ruff-0.15.18-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2186d9e940ae332ab293623a75b5f4fe49565f449954d50a72a046683aa6b809", size = 11208721, upload-time = "2026-06-18T18:25:41.327Z" },
-    { url = "https://files.pythonhosted.org/packages/88/d9/5baa2a30861adfb7022cf33c1e35b2fc18085b08c16f83eff4c7b99a5f48/ruff-0.15.18-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5c2abf140438032bc77b2284a6c9944ecd8a19e5f1c7b52b1b8e4a0a80d19a7a", size = 11678599, upload-time = "2026-06-18T18:25:13.607Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/1a/0725a7cfdc32ff769efb96ee782bec882e16448c5d9e3be947ec4c04ce27/ruff-0.15.18-py3-none-win32.whl", hash = "sha256:02299e6e9fa5b297a3f6d5d10d7bcd655c925b028bb8b9d4588214549c6b9ec4", size = 10901903, upload-time = "2026-06-18T18:25:24.755Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/51/805d9f6fb7970505c3504794a5ec350f605361b807fef4dcf214ebd35e72/ruff-0.15.18-py3-none-win_amd64.whl", hash = "sha256:dac80dc8d26b2257dbefabed62f5d255c3937b4ccb122da1fc634794fa3578b3", size = 12041189, upload-time = "2026-06-18T18:25:17.915Z" },
-    { url = "https://files.pythonhosted.org/packages/29/4c/67bb45e41609eb4726f1bfeb59e083cf91d14c696d4bd14c234a980be93d/ruff-0.15.18-py3-none-win_arm64.whl", hash = "sha256:b2c9257fcbd4a3e5b977a1904e6facca016bafe2edc17df24db67cfaee03b4e4", size = 11329958, upload-time = "2026-06-18T18:25:43.686Z" },
+    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
 ]
 
 [[package]]
@@ -3056,16 +3071,16 @@ wheels = [
 
 [[package]]
 name = "sqlglot"
-version = "30.11.0"
+version = "30.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/de/1542b04dcac0f85706fb8ce1ce7d2abcc230cdf10ea9e3aa7345393e5a90/sqlglot-30.11.0.tar.gz", hash = "sha256:1a23c6e2adb41da61fda46b1848d2fa26341d447fc0f0cd5ca21160362100991", size = 5893125, upload-time = "2026-06-11T17:11:37.845Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/ed/a6c45aec29353b6392ea34548c40af3ac6ffd6bc5572cf23b2ce250876fc/sqlglot-30.12.0.tar.gz", hash = "sha256:6b8369704662d4f654bc934cea4dd31c916c2a571b389210cb9e951a275e5fd9", size = 5905110, upload-time = "2026-06-26T14:09:40.408Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/86/53edf106e8cd3c883ccd0c6b470bf00ddf877a86e667665343b2d597329d/sqlglot-30.11.0-py3-none-any.whl", hash = "sha256:cffdee57d1f2f5472dc9f13087e618cf795841172b7d5ef78b63a051a52d2710", size = 698721, upload-time = "2026-06-11T17:11:35.737Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9e/82a390ecc85f066ff80affa01d195f744e3de60ad4d695b8de31c9a66da3/sqlglot-30.12.0-py3-none-any.whl", hash = "sha256:86cccc610073c645c03e72b55b60ae0518aa3253a7fc3bd56551370d003c6554", size = 707583, upload-time = "2026-06-26T14:09:38.525Z" },
 ]
 
 [[package]]
 name = "sqlspec"
-version = "0.50.1"
+version = "0.51.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mypy-extensions" },
@@ -3074,29 +3089,29 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/4b/bdb6d01830d3f1e173a9edf7261408f5cb60262138f05b8b39d69e6c332b/sqlspec-0.50.1.tar.gz", hash = "sha256:8b1c56f7aabb8e21d4953271152a5cf810ef06da81b24a21a2d05f12564f1034", size = 3433509, upload-time = "2026-06-22T22:04:40.023Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/4f/e541c38d24a1b00516f1a022026fd958f396a26fc67cff6ef4507a8cf512/sqlspec-0.51.0.tar.gz", hash = "sha256:0dcab63a49acaa547ee8405557a353990d2e9ef358f47eb44561fa519550792b", size = 3506926, upload-time = "2026-06-26T01:39:35.998Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/ee/8d4d4e4096957b83e7361ab718e88dbe6b9b03529fa5261f47e71ccc61cb/sqlspec-0.50.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:53118b80cde3d15ac1d32e1c3c7463bd73b21153edb7d6f919a4c939c1abd83e", size = 6164062, upload-time = "2026-06-22T22:04:02.745Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/78/11e038753c55627544742cf8959d81ee8412889db8ab637fc9cb33827320/sqlspec-0.50.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6db413e120ce74ca172fbac9a5476c70128b54c4aad6df5faafca2da547c212e", size = 7192428, upload-time = "2026-06-22T22:04:04.785Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/e3/81483bc84998d7b6afe879debc69df53316d80c10c18c5a0600a5ef933c8/sqlspec-0.50.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8ae120fc2014f4fc599162e74c1f910a2228c12c41a9568f87f8fe0ba9fc82fb", size = 6716603, upload-time = "2026-06-22T22:04:06.585Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/22/c93ab8bf5b6abf966e651af6b683cf286779d748c61bcb9d6788b8bdd471/sqlspec-0.50.1-cp310-cp310-win_amd64.whl", hash = "sha256:1f41b5f737256fb2f3284961edb46b756cf0e64bbf165b74ed301a41780f657a", size = 5406709, upload-time = "2026-06-22T22:04:08.419Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/9f/8592aebf2b466423a93d315840883b91df68454e2c04a2dc77e489b19f8e/sqlspec-0.50.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9da7545c35254e8c71bda3d7a4a85c1025f99c66262c0540f835b6123fc9c61b", size = 6123737, upload-time = "2026-06-22T22:04:10.315Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/58/a06d7d2b3229cdc8f52698a22bb4f52070b3959638bf5c9b8728cc9f1c78/sqlspec-0.50.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8f7e02764a7426c315e79706f8aab658d0a87d7fa25b02f60ee67949255fb9c6", size = 7141286, upload-time = "2026-06-22T22:04:12.329Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/a9/030e79553159f530da4d7479eaae1588faee0c46f3c2bbb3e3ebce1b1ca3/sqlspec-0.50.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:198e14d3ca66225c77056d8c008a28bdd58f0cbc957920fc70ac796c12ecbeb9", size = 6664328, upload-time = "2026-06-22T22:04:14.077Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/83/205cd526cfa9a9c0bd2fab650c816a57c9c63726b75c5fab3d45d07b3b71/sqlspec-0.50.1-cp311-cp311-win_amd64.whl", hash = "sha256:9f8d2a6c6ab79508d99af8900d2575323dfceb010aef6a57a60147442e61719f", size = 5391782, upload-time = "2026-06-22T22:04:15.96Z" },
-    { url = "https://files.pythonhosted.org/packages/49/dc/4dc7a21be171673de7bec5b7402c08d6717ef1a5436775e933051038f9da/sqlspec-0.50.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7eb1fb021306be66c9e6b0d4dca3bf38c5de537ea7b51b2b8418f3cc3fa10b8a", size = 6178899, upload-time = "2026-06-22T22:04:17.776Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/02/f5ed000f1154494bf0c19b64f0cfd9382313bd9c705b3ee9e27d0ef15179/sqlspec-0.50.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0277e16535c1669bda383459173c06c7fb61dad81c941c369a14723fd014d254", size = 7285308, upload-time = "2026-06-22T22:04:19.697Z" },
-    { url = "https://files.pythonhosted.org/packages/50/c0/7fb2c01c29c033b18f85959bd2ff7513952ce72f4cdeff1348c25cbd6246/sqlspec-0.50.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cfaecb86d052e856bf6c86af714e24d1ff941ce23f580ede66bdfe1c954d7204", size = 6737765, upload-time = "2026-06-22T22:04:21.789Z" },
-    { url = "https://files.pythonhosted.org/packages/31/d1/3328668d74a107aa13fcdf7d8cec6bfb755977356dabcb6a5bd91929dd30/sqlspec-0.50.1-cp312-cp312-win_amd64.whl", hash = "sha256:967f06892617d61e10ff2b64fe8826a2a8a618ab8b77fb042b57fd874ba95a38", size = 5438943, upload-time = "2026-06-22T22:04:23.426Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/27/f7db8f541bfe8ef6c1b5635c59ee8b308b59d8545472251e94c15a4f7a0f/sqlspec-0.50.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c7cac1bf79d5b3936fd70dc9e6a4925b733579f0d15ed341b52a3894db20fb6a", size = 6169489, upload-time = "2026-06-22T22:04:25.214Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/ec/4b0dab3c6bcc0454a9ae21743c89c13402133a9d1e6942577bf65cd0c388/sqlspec-0.50.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:033e782799d59edf38836af3b8e3fd54f38278e24cce47c54361a9448c0cf936", size = 7316946, upload-time = "2026-06-22T22:04:27.099Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/27/aceb243c6a024500c74c04d34fd13d01f43321e13eb97572bf17f493fbfb/sqlspec-0.50.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:262506815a867eff1004fc9470ad16bc7268506f711a403b54282c65af862dca", size = 6780270, upload-time = "2026-06-22T22:04:28.932Z" },
-    { url = "https://files.pythonhosted.org/packages/60/3d/7169e9246155934e78f07f5043bc4e1acfa4968dc483d6c807631b3dc4a7/sqlspec-0.50.1-cp313-cp313-win_amd64.whl", hash = "sha256:52dfbe159d4a819f8c5d48b81c4f3c44da3613934238ee35c549ff351bd16e9e", size = 5451459, upload-time = "2026-06-22T22:04:30.779Z" },
-    { url = "https://files.pythonhosted.org/packages/55/1e/e36fc5c8a653cb40ef84260a656263cae24c89cd29fa60b654302996ab1f/sqlspec-0.50.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7aaed86d8881b7643d4e11b42fd3ec452208d481e6ad1d9898e9f511d5ceb566", size = 6163766, upload-time = "2026-06-22T22:04:32.401Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/75/39fb6e12b24a811a05ad5cd79208ba0ba0359acbeeb510047da0a56446a3/sqlspec-0.50.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:179016a3c951e56919bad0bfd648f34a1680f9e222fd90a456cf1c7da97d5f79", size = 7291343, upload-time = "2026-06-22T22:04:33.932Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/bc/c2b723400e166f28992984817544d43d6aebd9b34e206878f8d348591fc3/sqlspec-0.50.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b75d6be44d8debd0fd73d745a368f0d891f01d163328c9950332a07ed9adcf34", size = 6790212, upload-time = "2026-06-22T22:04:35.598Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/ae/78d2b353405810cd3a93f82ba29508139771b3e56ef390927d487f3c8991/sqlspec-0.50.1-cp314-cp314-win_amd64.whl", hash = "sha256:8e5a3aa4bcabda950e9a8ecdc882ca067c8c92eae0e73ea52522e5bfd8ebb87b", size = 5529085, upload-time = "2026-06-22T22:04:37.087Z" },
-    { url = "https://files.pythonhosted.org/packages/78/08/04d81b68d8750022ddaf96a35f6656b4dd4a7e5a7664058b2e1b6543c923/sqlspec-0.50.1-py3-none-any.whl", hash = "sha256:4c49bccd32e8163431e7a53d2bfa4c3649392bdcfa9a3ab4bfe0a8f73a07084f", size = 1170599, upload-time = "2026-06-22T22:04:38.641Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/92/14a4bed577ec7e3035720aa40159d0faee763a2f551b14d39cfdb4e6f229/sqlspec-0.51.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f034aab81a726fee094c89589bcc0cb8af7d3782fe3852e17eb350b5021cdb7a", size = 6261591, upload-time = "2026-06-26T01:38:56.659Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/0e/3c37fef26f5996507d7e222664d11401ac55b928272fdccd9d9af5fc2c54/sqlspec-0.51.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:608607214760abcba899442d9b15c460de93827a96e975269045e8960ae3b8a2", size = 7296003, upload-time = "2026-06-26T01:38:59.031Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/b0/08ffa88eb64697823c7e11a1b69e830c2841b4edad9e8dc122a2dd02b7a0/sqlspec-0.51.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d04af5eff81034ad1af804cfcd819347097bd9717033943793de54c91bbf3643", size = 6814844, upload-time = "2026-06-26T01:39:00.956Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/82/be12f891ec23f01f66bd2709ff1196632096d214b297a80447f86c54135c/sqlspec-0.51.0-cp310-cp310-win_amd64.whl", hash = "sha256:577dd499ac5acb4d8db6ba3873a517795ec5c4e11af28c31e2a1836342fbbf7c", size = 5494243, upload-time = "2026-06-26T01:39:02.972Z" },
+    { url = "https://files.pythonhosted.org/packages/05/15/1490a651aa9835902a9f8a77e0477884cf888c99147781e675281d1703a8/sqlspec-0.51.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f41724bea9b68981176d734df063a5b75529fd9fdf0d7a8e7b3c7ffb231524f", size = 6219167, upload-time = "2026-06-26T01:39:04.69Z" },
+    { url = "https://files.pythonhosted.org/packages/52/bb/d7f7056ccc30143cd5537c9a9e6493009fe1754e50aa7562c1efea6d05c8/sqlspec-0.51.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4a3cc5f58c2d1d0d665ec7e8d5cfd0fb5692f026c5067d312bc22f8de0ed789a", size = 7243140, upload-time = "2026-06-26T01:39:06.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/86/878346ba61bc7824480ef859b7869e56107297aa5587f5d1aeb7cc53fb4e/sqlspec-0.51.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:47532dd93217819db6fc0d50eb5f53f37afdffffc78b0a980a8938b9f9fbb04d", size = 6760227, upload-time = "2026-06-26T01:39:08.488Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/1b/3acafc0edcc8475b81a6599065f7689030e4c7ed8141c69d2a24cd504574/sqlspec-0.51.0-cp311-cp311-win_amd64.whl", hash = "sha256:a0942bc6a18953731d53761eca65dea6139f859d039c3cb81cdb1bb22b2861c9", size = 5481860, upload-time = "2026-06-26T01:39:10.397Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/30/dda9cfe617f5164c41f227750fcee1bea2befbfbca036219c7e36532bd5d/sqlspec-0.51.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:add924da522d948a956d86b332194f87f76bd1539bcfac88605a520f96429eeb", size = 6274902, upload-time = "2026-06-26T01:39:12.23Z" },
+    { url = "https://files.pythonhosted.org/packages/11/ec/c2ae83cbb15d4fe72c8df56ba754a7cdc389054b4827bdee771a9befe33d/sqlspec-0.51.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:cc91bd400197e6dd533b41f5fd2c875984d65b5be45089720b6111bdeb3eb433", size = 7389346, upload-time = "2026-06-26T01:39:14.847Z" },
+    { url = "https://files.pythonhosted.org/packages/07/db/7b94b9136caac055b621a7cb47e07f5271d99ddde71c05e70f5e8aaeedfa/sqlspec-0.51.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe6a1e02b2bb7545493058298d8ac503203a7e8f9d390605cdad1410b7386fce", size = 6838964, upload-time = "2026-06-26T01:39:16.727Z" },
+    { url = "https://files.pythonhosted.org/packages/13/40/fb1e6f1b151855c0e365cad8a6eff5360dcc6a8a07342f5a8e7c855f324d/sqlspec-0.51.0-cp312-cp312-win_amd64.whl", hash = "sha256:3901e99d0d205332a57410d8bd3af61c60c62df76d4ea6f1c40f2e3fcfd6bbd1", size = 5527412, upload-time = "2026-06-26T01:39:18.464Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/7c/b6477586948f4697893d226497fdeacabf849599e762fc453eb8d4629cd1/sqlspec-0.51.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e66a60ded88489d187f22970c0338b664af42680a4f0dc7a9bff47fb198b704e", size = 6267198, upload-time = "2026-06-26T01:39:20.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/5e/8e9de66928963e5a4807238ca84939993ff9579e554445a43a767fb01db3/sqlspec-0.51.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d9b231c9095591177d26291710cc08c651ee8637bdab2c7d20476121fcc16044", size = 7419963, upload-time = "2026-06-26T01:39:21.843Z" },
+    { url = "https://files.pythonhosted.org/packages/03/fd/274ed9d303c2f1887e50ec9054113318d2f0478b9cd8101ab436604a9d97/sqlspec-0.51.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f1cceb1c8bfc90d8a629994a5720e88e773173795ff24962400492c82070d50", size = 6882901, upload-time = "2026-06-26T01:39:23.639Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/f9/a4f11037ec1e9b99b3dad7b87a8f8c899af4f00b7b3bac3cff0391b537ad/sqlspec-0.51.0-cp313-cp313-win_amd64.whl", hash = "sha256:8014aeae64b98cca66bf1d947971b795fa65a30504c2762773295cd61a4a4edd", size = 5535939, upload-time = "2026-06-26T01:39:25.907Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ff/9a2f997aa3017d7ff06175aaf1e2600062b710ff5a80780c101f6605cec2/sqlspec-0.51.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dbc79bbd578f2bafc897672371282706ef8a3bf481f70eb24e24d6c9de346eab", size = 6354349, upload-time = "2026-06-26T01:39:27.428Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ea/af5f84ee20ce874171cb945b4a72ee87ae156438f37d0ed3b0e04c8277e6/sqlspec-0.51.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4a74280c961793b7bc03fd1714da299334e8f21f9e84b1bf292a3e044cfb7b44", size = 7392040, upload-time = "2026-06-26T01:39:29.195Z" },
+    { url = "https://files.pythonhosted.org/packages/96/fe/307fe127df80d0db8973428cd86045f57d7d07ba8520691c3fe9b1205c02/sqlspec-0.51.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3d1d4794c29662a4958253f2709004b4eca39261179a9fe6221029bb5e8094a6", size = 6893490, upload-time = "2026-06-26T01:39:30.973Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6e/36df11480db2450c42726911b329f8afd72f3013c8c90c4329d0e51781fb/sqlspec-0.51.0-cp314-cp314-win_amd64.whl", hash = "sha256:798f56f48626d18735f0f0528a4f5920405655de82c93fa8703f5f7d688177a8", size = 5619399, upload-time = "2026-06-26T01:39:32.593Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/3c/1a0234da096e340a5962755c5f4d957adca4b2e6c813faebcfd95de7b9ab/sqlspec-0.51.0-py3-none-any.whl", hash = "sha256:500d9a4830c53370fe9acd6f6889f5ccf102d1a8cc61101a0761caea962a7e74", size = 1215140, upload-time = "2026-06-26T01:39:34.398Z" },
 ]
 
 [package.optional-dependencies]
@@ -3261,14 +3276,14 @@ wheels = [
 
 [[package]]
 name = "tzlocal"
-version = "5.4.3"
+version = "5.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/55/15e2340963d2bfedcc6042da3911438fd336f8ae96b65bdbe3a29766da0c/tzlocal-5.4.3.tar.gz", hash = "sha256:3a8c9bc18cf47e1dcde252ea0e6a72a6cde320a400b6ac6db1f1f8cccd553c00", size = 30873, upload-time = "2026-06-17T04:17:41.764Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/5b/879b2f932adfa7a053c360d50bc896c977fa6426109185f7c12ebdd0cb9d/tzlocal-5.4.4.tar.gz", hash = "sha256:8dbb8660838688a7b6ba4fed31d18dedf842afb4d47ca050d6d891c2c15f3be4", size = 31170, upload-time = "2026-06-29T08:03:40.026Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/28/fc144409c71569e928585f8f3c629d80d1ca3ef40175e9222f01588f98c9/tzlocal-5.4.3-py3-none-any.whl", hash = "sha256:24ce97bb58e2a973f7640ec2553ab4e6f6d5a0d0d1aa9dc43bca21d89e1feb82", size = 18039, upload-time = "2026-06-17T04:17:40.027Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/a4/017a7a6cbe387d961a688ec31364ae60a5c4e22c96ae9921b79a947c855d/tzlocal-5.4.4-py3-none-any.whl", hash = "sha256:aae09f0126a8a86fa736be266eb4a471380d26a0de3bc14844e7821fee3e2a15", size = 18115, upload-time = "2026-06-29T08:03:38.666Z" },
 ]
 
 [[package]]
@@ -3569,23 +3584,23 @@ wheels = [
 
 [[package]]
 name = "wcmatch"
-version = "10.1"
+version = "10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bracex" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/98/eb989c3113908e2ef46d940a53695a1ebb4be5a732c4a4f700be8f8d682b/wcmatch-10.2.tar.gz", hash = "sha256:92204839e3e9c945e1e71d7e1e4edeab2601ed50a5c51ff4f3f97ca711eeb738", size = 132499, upload-time = "2026-06-30T00:50:07.198Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/73/aef4aaf16b8d785762e2b14cf321a9178cc84a1bf4c40f58320f499a2d65/wcmatch-10.2-py3-none-any.whl", hash = "sha256:f1a79e80ccbe296907b7eaf57d8d3bc49eab0b428d35f7d09986b5079b6e4a5d", size = 39742, upload-time = "2026-06-30T00:50:05.927Z" },
 ]
 
 [[package]]
 name = "wcwidth"
-version = "0.8.1"
+version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/49/b4/51fe890511f0f242d07cb1ebe6a5b6db417262b9d2568b460347c57d95cc/wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9", size = 1466072, upload-time = "2026-06-08T05:57:23.146Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8", size = 323092, upload-time = "2026-06-08T05:57:21.413Z" },
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Refreshes Litestar ecosystem skill guidance against current stable releases for `litestar-mcp`, `litestar-vite`, `sqlspec`, and `advanced-alchemy`.
- Adds a new first-party `litestar-queues` skill covering plugin setup, queue services, task declaration, workers, schedules, task results, events/progress helpers, dependency resolution, and backend selection.
- Wires `litestar-queues` into hook detection, validation imports, README inventory, tests, and the generated Codex package payload.
- Keeps the v0.5.0 package/manifest version sync and lockfile/tooling updates in the release scope.

## Release guidance covered

- `litestar-mcp` v0.7.0 through v0.9.0, including standalone `MCP(...)`, stdio transport, decorator APIs, callback/context behavior, and current Streamable HTTP verification guidance.
- `litestar-vite` v0.24.0 through v0.25.0, including Inertia fixes and Vite 8.1 HMR WebSocket option guidance.
- `sqlspec` v0.50.0 through v0.51.0, including streaming, Arrow export, native bulk ingest, ADK 2 stores and migration warning, metadata/statistics, bounded async bridge controls, and cloud job/session controls.
- `advanced-alchemy` v1.11.0, including vector and OTP types, filters, schema dump behavior, delete-many support, Oracle notes, and Typer CLI compatibility.
- `litestar-queues` v0.1.0 as a new first-party skill.

## Audit results

- MCP audit: corrected initialization verification and standalone `MCP(...)` app-kwarg guidance.
- SQLSpec audit: corrected adapter async flags, service pagination examples, `execute()` result semantics, ADK 2 migration warning, Arrow `native_only` guidance, and styleguide reference links.
- Queues audit: tightened worker configuration, migration, and Advanced Alchemy backend ownership guidance.
- Vite / Advanced Alchemy audit: corrected Oracle vector type guidance.
- Packaging audit: confirmed generated Codex payload, README inventory, hook map, validation extras, upstream import roots, and version manifests are wired.